### PR TITLE
Reduce extra history entries

### DIFF
--- a/src/code-store.js
+++ b/src/code-store.js
@@ -35,5 +35,5 @@ export const fromUrl = data => {
 };
 export const updateCodeStore = newState => {
   codeStore.set(newState);
-  push('/edit/' + Base64.encodeURI(JSON.stringify(newState)))
+  replace('/edit/' + Base64.encodeURI(JSON.stringify(newState)))
 };

--- a/src/components/Config.svelte
+++ b/src/components/Config.svelte
@@ -38,7 +38,7 @@ const handleConfUpdate =  conf => {
 		console.log('Error in parsed', e);
 		configErrorStore.set(e);
 		const str = JSON.stringify({ code, mermaid: oldConf });
-		push('/edit/' + Base64.encodeURI(str))
+		replace('/edit/' + Base64.encodeURI(str))
 	}
 };
 

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -36,7 +36,7 @@ const handleCodeUpdate = code => {
 			codeErrorStore.set(e);
 			console.log('Error in parsed', e.hash);
 			const str = JSON.stringify({ code: code, mermaid: conf });
-			push('/edit/' + Base64.encodeURI(str))
+			replace('/edit/' + Base64.encodeURI(str))
 			const l = e.hash.line;
 			decArr.push(edit.deltaDecorations([], [
 				{ range: new monaco.Range(e.hash.loc.first_line,e.hash.loc.last_line,e.hash.loc.first_column,e.hash.loc.last_column), options: { inlineClassName: 'myInlineDecoration' }}]


### PR DESCRIPTION
Hi! 👋 I love Mermaid, and the live editor is super useful. I find that it adds a lot of unnecessary entries to my browser history, though, so I'm wondering if you'd consider this change. This makes a number of changes to how the editor updates browser history.

- Editor keystrokes changes URL, but don't add a new history entry per-keystroke (for both the diagram and config editors)
- Any other calls to `updateCodeStore` will also replace URL instead of pushing a history entry

Personally, I don't think there's a need to push history entries for any of these scenarios. Now, when navigating to the editor, making changes, then hitting the `back` button, the browser will return to the page the user was on before navigating to the editor.