### PR TITLE
fix(marketing-links): fixes Mermaid CLI link

### DIFF
--- a/src/routes/Edit.svelte
+++ b/src/routes/Edit.svelte
@@ -229,7 +229,7 @@ onMount(async () => {
 					</li>
 					<li>
 						<a
-							href='https://github.com/mermaid-js/mermaid.cli'
+							href='https://github.com/mermaid-js/mermaid-cli'
 							target='_blank'
 						>
 							Mermaid CLI


### PR DESCRIPTION
The old link to the Mermaid CLI is broken.