### PR TITLE
State that markdown is base64 encoded for urls

### DIFF
--- a/src/components/Links.svelte
+++ b/src/components/Links.svelte
@@ -100,6 +100,7 @@ label[for="markdown"] {
 	<a href="{url}" download='' on:click={onDownloadPNG}>
 		Download PNG
 	</a>
+	(markdown is base64 encoded for these urls)
 </div>
 <p>
   <label for="markdown">Copy Markdown</label>


### PR DESCRIPTION
Fixes #35