### PR TITLE
Added editor link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Contributors are welcome
 
-If you want to speed up the progress for mermaid-cli, join the slack channel and contact knsv.
+If you want to speed up the progress for mermaid-live-editor, join the slack channel and contact knsv.
 
 # mermaid-live-editor
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Edit, preview and share mermaid charts/diagrams.
 - Get a link to edit the diagram so that someone else can tweak it and send a new link back
 
 
+## Live demo
+
+You can try out a live version [here](https://mermaid-js.github.io/mermaid-live-editor/).
+
 ## Setup
 
 This project is set up using [Yarn](https://classic.yarnpkg.com/en/docs/getting-started):


### PR DESCRIPTION
Currently, there is no link to the Live Editor in the README.md which is added with this PR.

In case this is deliberate, feel free to simply close the pr.