### PR TITLE
Change initial default Writable type

### DIFF
--- a/src/code-store.js
+++ b/src/code-store.js
@@ -4,7 +4,7 @@ import mermaid from '@mermaid';
 import { Base64 } from 'js-base64';
 import { push, pop, replace } from 'svelte-spa-router';
 
-export const codeStore = writable(undefined);
+export const codeStore = writable({});
 export const fromUrl = (data) => {
   let code;
   let state;


### PR DESCRIPTION
## :bookmark_tabs: Summary
Brief description about the content of your PR:
I changed the default initial type of codeStore from undefined to an empty object. To avoid this error for the first start :
```
Cannot set property 'code' of undefined
```

Resolves #71 

## :straight_ruler: Design Decisions


### :clipboard: Tasks
Make sure you
- [✓] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [✓] :bookmark: targeted `master` branch 
