### PR TITLE
Bump node.js from 13.6 to 14.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #                                        docker stop mermaid-live-editor
 
 
-FROM 14.16.0-alpine3.13 as mermaid-live-editor-builder
+FROM node:14.16.0-alpine3.13 as mermaid-live-editor-builder
 COPY --chown=node:node . /home
 WORKDIR /home
 RUN yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #                                        docker stop mermaid-live-editor
 
 
-FROM node:15.11.0-alpine3.13 as mermaid-live-editor-builder
+FROM 14.16.0-alpine3.13 as mermaid-live-editor-builder
 COPY --chown=node:node . /home
 WORKDIR /home
 RUN yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #                                        docker stop mermaid-live-editor
 
 
-FROM node:13.6.0-alpine as mermaid-live-editor-builder
+FROM node:15.11.0-alpine3.13 as mermaid-live-editor-builder
 COPY --chown=node:node . /home
 WORKDIR /home
 RUN yarn install


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently building the docker image fails with the following error:

```
$ docker build -t mermaid-editor github.com/mermaid-js/mermaid-live-editor
 
...

=> [mermaid-live-editor-builder 4/5] RUN yarn install                                                                                                                                  25.2s= => ERROR [mermaid-live-editor-builder 5/5] RUN yarn build                                                                                                                               0.8s
------                                                                                                                                                                                         > [mermaid-live-editor-builder 5/5] RUN yarn build:
#9 0.399 yarn run v1.21.1
#9 0.432 $ webpack build
#9 0.748 internal/modules/cjs/loader.js:628
#9 0.748   throw e;
#9 0.748   ^
#9 0.748
#9 0.748 Error: No valid exports main found for '/home/node_modules/colorette'
#9 0.748     at resolveExportsTarget (internal/modules/cjs/loader.js:625:9)
#9 0.748     at applyExports (internal/modules/cjs/loader.js:502:14)
#9 0.748     at resolveExports (internal/modules/cjs/loader.js:551:12)
#9 0.748     at Function.Module._findPath (internal/modules/cjs/loader.js:657:22)
#9 0.748     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:960:27)
#9 0.748     at Function.Module._load (internal/modules/cjs/loader.js:855:27)
#9 0.748     at Module.require (internal/modules/cjs/loader.js:1033:19)
#9 0.748     at require (/home/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
#9 0.748     at Object.<anonymous> (/home/node_modules/webpack-cli/lib/webpack-cli.js:10:66)
#9 0.748     at Module._compile (/home/node_modules/v8-compile-cache/v8-compile-cache.js:192:30) {
#9 0.748   code: 'MODULE_NOT_FOUND'
#9 0.748 }
#9 0.763 error Command failed with exit code 1.
#9 0.763 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
------
executor failed running [/bin/sh -c yarn build]: exit code: 1
```

This is because colorette doesn't work with Node.js 13: https://github.com/jorgebucaran/colorette/issues/46

## :straight_ruler: Design Decisions

I bumped the node.js version to the latest.

Any node.js other than 13 would work. If there's a reason to not use the latest version, we can use 14.16.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `master` branch 
