### PR TITLE
fix: blank space on top/bottom when export image/svg

### DIFF
--- a/src/lib/components/actions.svelte
+++ b/src/lib/components/actions.svelte
@@ -14,6 +14,7 @@
 		svg?.setAttribute('width', `${width}px`); // Workaround https://stackoverflow.com/questions/28690643/firefox-error-rendering-an-svg-image-to-html5-canvas-with-drawimage
 		if (!svg) {
 			svg = document.querySelector('#container svg');
+			svg.removeAttribute('height');
 		}
 		const svgString = svg.outerHTML
 			.replaceAll('<br>', '<br/>')
@@ -24,6 +25,7 @@
 	const exportImage = (event: Event, exporter: Exporter) => {
 		const canvas: HTMLCanvasElement = document.createElement('canvas');
 		const svg: HTMLElement = document.querySelector('#container svg');
+		svg.removeAttribute('height');
 		const box: DOMRect = svg.getBoundingClientRect();
 		canvas.width = box.width;
 		canvas.height = box.height;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Remove blank space on top/bottom when export image/svg

Resolves #566 

## :straight_ruler: Design Decisions

Before export image, svg. Remove `height` attribute on `svg` element.
So browser when re-calculate new fitable height.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
