### PR TITLE
Kroki support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ docker run --publish 8000:80 ghcr.io/mermaid-js/mermaid-live-editor
 When building, Set the Environment variable MERMAID_RENDERER_URL to the rendering service.
 Default is `https://mermaid.ink`
 
+### To configure Kroki Instance URL
+
+When building, Set the Environment variable MERMAID_KROKI_RENDERER_URL to your Kroki instance.
+Default is `https://kroki.io`
+
 ### Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"moment": "^2.29.1",
 		"monaco-editor": "^0.31.1",
 		"monaco-mermaid": "^1.0.1",
+		"pako": "1.0.10",
 		"random-word-slugs": "^0.1.6"
 	},
 	"lint-staged": {

--- a/src/lib/components/actions.svelte
+++ b/src/lib/components/actions.svelte
@@ -141,8 +141,7 @@
 	};
 
 	const onKrokiClick = () => {
-		const stateCopy = JSON.parse(JSON.stringify($codeStore));
-		const krokiCode = getKrokiCode(stateCopy.code);
+		const krokiCode = getKrokiCode($codeStore.code);
 		const krokiUrl = `${krokiRendererUrl}/mermaid/svg/${krokiCode}`;
 		return window.open(krokiUrl, '_blank');
 	};

--- a/src/lib/components/actions.svelte
+++ b/src/lib/components/actions.svelte
@@ -4,7 +4,7 @@
 	import Card from '$lib/components/card/card.svelte';
 	import { rendererUrl, krokiRendererUrl } from '$lib/util/env';
 	import { base64State, codeStore } from '$lib/util/state';
-	import { toBase64 } from 'js-base64';
+	import { toBase64, btoa as jsbtoa } from 'js-base64';
 	import moment from 'moment';
 	import pako from 'pako';
 
@@ -150,7 +150,7 @@
 	const getKrokiCode = (source) => {
 		const data = textEncode(source);
 		const compressed = pako.deflate(data, { level: 9, to: 'string' });
-		let result = btoa(compressed).replace(/\+/g, '-').replace(/\//g, '_');
+		let result = jsbtoa(compressed).replace(/\+/g, '-').replace(/\//g, '_');
 		return result;
 	};
 

--- a/src/lib/components/actions.svelte
+++ b/src/lib/components/actions.svelte
@@ -140,6 +140,13 @@
 		return result;
 	};
 
+	const onKrokiClick = () => {
+		const stateCopy = JSON.parse(JSON.stringify($codeStore));
+		const krokiCode = getKrokiCode(stateCopy.code);
+		const krokiUrl = `${krokiRendererUrl}/mermaid/svg/${krokiCode}`;
+		return window.open(krokiUrl, '_blank');
+	};
+
 	const getKrokiCode = (source) => {
 		const data = textEncode(source);
 		const compressed = pako.deflate(data, { level: 9, to: 'string' });
@@ -149,7 +156,6 @@
 
 	let iUrl: string;
 	let svgUrl: string;
-	let krokiUrl: string;
 	let mdCode: string;
 	let imagemodeselected = 'auto';
 	let userimagesize = 1080;
@@ -164,10 +170,8 @@
 			stateCopy.mermaid = JSON.parse(stateCopy.mermaid);
 		}
 		const b64Code = toBase64(JSON.stringify(stateCopy), true);
-		const krokiCode = getKrokiCode(stateCopy.code);
 		iUrl = `${rendererUrl}/img/${b64Code}`;
 		svgUrl = `${rendererUrl}/svg/${b64Code}`;
-		krokiUrl = `${krokiRendererUrl}/mermaid/svg/${krokiCode}`;
 		mdCode = `[![](${iUrl})](${window.location.protocol}//${window.location.host}${window.location.pathname}#${encodedState})`;
 	});
 </script>
@@ -191,8 +195,8 @@
 		<button class="action-btn flex-auto">
 			<a target="_blank" href={svgUrl}><i class="fas fa-external-link-alt mr-2" /> SVG</a>
 		</button>
-		<button class="action-btn flex-auto">
-			<a target="_blank" href={krokiUrl}><i class="fas fa-external-link-alt mr-2" /> Kroki</a>
+		<button class="action-btn flex-auto" on:click={onKrokiClick}>
+			<i class="fas fa-external-link-alt mr-2" /> Kroki
 		</button>
 
 		<div class="flex gap-2 items-center">

--- a/src/lib/util/env.ts
+++ b/src/lib/util/env.ts
@@ -1,1 +1,2 @@
 export const rendererUrl = import.meta.env.MERMAID_RENDERER_URL ?? 'https://mermaid.ink';
+export const krokiRendererUrl = import.meta.env.MERMAID_KROKI_RENDERER_URL ?? 'https://kroki.io';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3424,6 +3424,11 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+pako@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
+  integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"


### PR DESCRIPTION

## :bookmark_tabs: Summary
This commit adds support for generating links to be rendered with
[Kroki](https://kroki.io) compatible renderer. Apart from supporting many other
diagram formats, it directly benefits Mermaid editor because it generates much
shorter URLs (due to the compression).

Custom Kroki URL can be configured through environment variable if you want to
use a self-hosted instance of Kroki.