### PR TITLE
Fix tab style exception

### DIFF
--- a/src/lib/components/card/tabs.svelte
+++ b/src/lib/components/card/tabs.svelte
@@ -26,7 +26,7 @@
 		<ul class="tabs" transition:fade>
 			{#each tabs as tab}
 				<div
-					class="tab tab-lifted text-primary-content {activeTabID === tab.id ? 'tab-active' : ''}"
+					class="tab tab-lifted {activeTabID === tab.id ? 'tab-active' : 'text-primary-content'}"
 					on:click|stopPropagation={() => toggleTabs(tab)}>
 					<i class="mr-1 {tab.icon}" />
 					{tab.title}


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR:
Fix style exception when tab is selected

Resolves #689 

## :straight_ruler: Design Decisions
The reason for the exception is that there is a conflict between `.text-primary-content` and `.tab-active`, and the two `class` are not compatible with `color` and `background-color`.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :bookmark: targeted `develop` branch
