### PR TITLE
Fixes #681 - Add font awesome CSS to exported SVG

### DIFF
--- a/src/lib/components/actions.svelte
+++ b/src/lib/components/actions.svelte
@@ -14,7 +14,7 @@
 		svg?.setAttribute('height', `${height}px`);
 		svg?.setAttribute('width', `${width}px`); // Workaround https://stackoverflow.com/questions/28690643/firefox-error-rendering-an-svg-image-to-html5-canvas-with-drawimage
 		if (!svg) {
-			svg = document.querySelector('#container svg');
+			svg = getSvgEl();
 		}
 		const svgString = svg.outerHTML
 			.replaceAll('<br>', '<br/>')
@@ -24,7 +24,7 @@
 
 	const exportImage = (event: Event, exporter: Exporter) => {
 		const canvas: HTMLCanvasElement = document.createElement('canvas');
-		const svg: HTMLElement = document.querySelector('#container svg');
+		const svg: HTMLElement = getSvgEl();
 		const box: DOMRect = svg.getBoundingClientRect();
 		canvas.width = box.width;
 		canvas.height = box.height;
@@ -48,6 +48,22 @@
 
 		event.stopPropagation();
 		event.preventDefault();
+	};
+
+	const getSvgEl = () => {
+		const svgEl: HTMLElement = document
+			.querySelector('#container svg')
+			.cloneNode(true) as HTMLElement;
+		const fontAwesomeCdnUrl = Array.from(document.head.getElementsByTagName('link'))
+			.map((l) => l.href)
+			.find((h) => h && h.includes('font-awesome'));
+		if (fontAwesomeCdnUrl == null) {
+			return svgEl;
+		}
+		const styleEl = document.createElement('style');
+		styleEl.innerText = `@import url("${fontAwesomeCdnUrl}");'`;
+		svgEl.prepend(styleEl);
+		return svgEl;
 	};
 
 	const simulateDownload = (download: string, href: string): void => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

In the Live Editor view, the _font awesome_ CSS is loaded in the HTML page head. When exporting to SVG, the CSS is not included in the export. This leads to font awesome icons not displaying within the SVG export. This change includes the _font awesome_ CSS in the exported SVG through a [CSS @import rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@import).

Resolves #681

## :straight_ruler: Design Decisions

Ideally, the font awesome CSS/fonts would be embedded in the exported SVG. Since the Live Editor HTML page is using a CDN, doing this would require a larger change.

### Further Drawbacks

This does not fix the issue of icons displaying in export to PNG.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [X] :computer: have added unit/e2e tests (if appropriate)
- [X] :bookmark: targeted `develop` branch
