### PR TITLE
fix #796: Export SVG fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "pwa-chrome",
+			"request": "launch",
+			"name": "Launch Chrome against localhost",
+			"url": "http://localhost:3000",
+			"webRoot": "${workspaceFolder}"
+		}
+	]
+}

--- a/src/lib/components/actions.svelte
+++ b/src/lib/components/actions.svelte
@@ -57,6 +57,7 @@
 		const svgEl: HTMLElement = document
 			.querySelector('#container svg')
 			.cloneNode(true) as HTMLElement;
+		svgEl.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
 		const fontAwesomeCdnUrl = Array.from(document.head.getElementsByTagName('link'))
 			.map((l) => l.href)
 			.find((h) => h && h.includes('font-awesome'));


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR:

Add `setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');`

Resolves #796

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable:

This is a temporary fix till the main issue is fixed in mermaid library.
Only few diagrams have this attribute added in mermaid. So SVGs of other diagrams will throw the error.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `master` branch
