### PR TITLE
Fix an issue where the image is jpg format on mermaid.ink

### DIFF
--- a/src/lib/components/actions.svelte
+++ b/src/lib/components/actions.svelte
@@ -166,7 +166,7 @@
 		isNetlify = true;
 	}
 	stateStore.subscribe(({ code, serialized }) => {
-		iUrl = `${rendererUrl}/img/${serialized}`;
+		iUrl = `${rendererUrl}/img/${serialized}?type=png`;
 		svgUrl = `${rendererUrl}/svg/${serialized}`;
 		krokiUrl = `${krokiRendererUrl}/mermaid/svg/${pakoSerde.serialize(code)}`;
 		mdCode = `[![](${iUrl})](${window.location.protocol}//${window.location.host}${window.location.pathname}#${serialized})`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,9 +1024,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001407:
-  version "1.0.30001418"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz"
-  integrity sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==
+  version "1.0.30001419"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz"
+  integrity sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
## :bookmark_tabs: Summary

On UI, the button indicates that the image of the link is `PNG`:
![SCR-20221015-g9d](https://user-images.githubusercontent.com/87983/195977753-36e6d383-fb75-4451-bfb5-41b23d9d6b7e.png)

But [mermaid.ink/img/:code](https://mermaid.ink) renders  images as `jpg` by default:

```
curl -I 'https://mermaid.ink/img/pako:eNpNkMtqw0AMRX9FaNVC_ANeFBo7zSalhWbnyUJ4lMyQzIOxTAm2_70zDqXdSVfn6jVhHzRjjZdE0cCxVR7gtWtMsoM4Gk5QVS_zngVc8HyfYfu0DzCYEKP1l-dCbwsCzXQoEIMY669LKTSr98PzDG13oCghnv7043eYYdfZT5Mb_9dN4ux4685Un6nqKUFDKQNKlOAGHSdHVueVp2JSKIYdK6xzqCldFSq_ZG6MmoR32kpIWEsaeYM0Svi6-_43fzCtpXy9wzzuNmSVV8_74y_re5YfuhBiBA'
HTTP/2 200
date: Sat, 15 Oct 2022 08:56:00 GMT
content-type: image/jpeg
content-length: 17870
...
```

This PR is an attempt to rectify this error by explicitly specifying the format in the URL.

Resolves jihchi/mermaid.ink#110, thanks @phibo23 for pointing out the issue.

## :straight_ruler: Design Decisions

Ask [mermaid.ink/img/:code](mermaid.ink) renders  images as `png` by adding `?type=png` query to the URL.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
