### PR TITLE
Fixing link to Tutorials

### DIFF
--- a/src/lib/components/navbar.svelte
+++ b/src/lib/components/navbar.svelte
@@ -21,7 +21,7 @@
     },
     {
       title: 'Tutorial',
-      href: 'https://github.com/mermaid-js/mermaid/blob/develop/docs/Tutorials.md'
+      href: 'https://mermaid-js.github.io/mermaid/#/Tutorials'
     },
     {
       title: 'Mermaid',


### PR DESCRIPTION
## :bookmark_tabs: Summary

The link to "TUTORIAL" in the top-level navigation was broken.
This PR fixes that link.

## :straight_ruler: Design Decisions

I wasn't sure which of these to point to:
1. https://mermaid-js.github.io/mermaid/#/Tutorials
1. https://github.com/mermaid-js/mermaid/blob/develop/docs/config/Tutorials.md
1. https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/config/Tutorials.md

I opted for (1) as that is consistent with the type of link chosen for "DOCUMENTATION".
Also seemed to be best to bring users to the main documentation site.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :bookmark: targeted `develop` branch
