### PR TITLE
Nav: Fixed broken tutorial link

### DIFF
--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -21,7 +21,7 @@
     },
     {
       title: 'Tutorial',
-      href: 'https://github.com/mermaid-js/mermaid/blob/develop/docs/Tutorials.md'
+      href: 'https://mermaid-js.github.io/mermaid/#/./Tutorials'
     },
     {
       title: 'Mermaid',


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR:
The link to tutorials from Mermaid Live Editor does not work.  404: "'The 'mermaid-js/mermaid' repository doesn't contain the 'docs/Tutorials.md' path in 'develop'".  I simply fixed this link.

<img width="1421" alt="Screen Shot 2022-11-29 at 8 56 44 PM" src="https://user-images.githubusercontent.com/63523604/204711749-cdc7fbe6-86cf-491a-8896-02e99e20790d.png">
<img width="553" alt="Screen Shot 2022-11-29 at 8 57 23 PM" src="https://user-images.githubusercontent.com/63523604/204711758-e0938c44-e9ec-49a7-97fa-a8d35cbfcbb4.png">

There is no issue id - fixing the link takes less time than creating an issue. 

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable:
I chose the link to the tutorials on mermaid-js.github.io rather than https://github.com/mermaid-js/mermaid/blob/develop/docs/config/Tutorials.md. 

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [X] :bookmark: targeted `develop` branch
