### PR TITLE
Fix editor broken moving between code and config

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -30,6 +30,7 @@
     const newText = editorMode === 'code' ? code : mermaid;
     if (newText !== text) {
       // console.log('updating editor text', newText);
+      editor.setScrollTop(0);
       editor.setValue(newText);
       text = newText;
     }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Toggling "Code" and "Config" tabs is broken when you scroll editor

## :straight_ruler: Design Decisions

When changing between tabs scroll top to make sure the current line always makes sense

### Before (current prod)

https://user-images.githubusercontent.com/963490/232318872-91d2e7d8-bf32-435c-93da-ea0d746bf2a6.mov

```
caught Error: Illegal value for lineNumber

Error: Illegal value for lineNumber
    at Bt.getLineMaxColumn (textModel.ts:778:10)
    at _.getViewLineMaxColumn (modelLineProjection.ts:340:16)
    at t.getViewLineMaxColumn (viewModelLines.ts:740:62)
    at v.getLineMaxColumn (viewModelImpl.ts:672:22)
    at new k (viewLinesViewportData.ts:68:16)
    at Q._actualRender (view.ts:393:24)
    at view.ts:364:30
    at se (view.ts:553:10)
    at Q._renderNow (view.ts:364:3)
    at Q._flushAccumulatedAndRenderNow (view.ts:230:8)
    at errors.ts:26:12
```

### After (changes from this PR)

https://user-images.githubusercontent.com/963490/232318981-f5ec6c70-a2a4-46de-ad8d-3f31d89e8085.mov



### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [X] :bookmark: targeted `develop` branch
