### PR TITLE
Use nginx-unprivileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ WORKDIR /home
 RUN yarn install
 RUN yarn build
 
-FROM nginx:alpine as mermaid-live-editor-runner
+FROM nginxinc/nginx-unprivileged:alpine as mermaid-live-editor-runner
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=mermaid-live-editor-builder --chown=nginx:nginx /home/docs /usr/share/nginx/html


### PR DESCRIPTION
## :bookmark_tabs: Summary

This allows the Docker image to run as an unprivileged user instead of root.

Resolves #249

## :straight_ruler: Design Decisions

- Changes `nginx` image to `nginxinc/nginx-unprivileged`
- Keeps port on 80, as it's supported from Docker 20.03

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [X] :bookmark: targeted `develop` branch
