### PR TITLE
Fix #1230 Docker: use 8080 port instead of 80 to reduce privilege requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Two-stage  docker container for mermaid-js/mermaid-live-editor
 # Build              : docker build -t mermaid-js/mermaid-live-editor .
-# Run                : docker run --name mermaid-live-editor --publish 8080:80 mermaid-js/mermaid-live-editor
+# Run                : docker run --name mermaid-live-editor --publish 8080:8080 mermaid-js/mermaid-live-editor
 # Start              : docker start mermaid-live-editor
 # Use webbrowser     : http://localhost:8080
 # Stop               : press ctrl + c 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can try out a live version [here](https://mermaid.live/).
 ### Run published image
 
 ```bash
-docker run --publish 8000:80 ghcr.io/mermaid-js/mermaid-live-editor
+docker run --publish 8000:8080 ghcr.io/mermaid-js/mermaid-live-editor
 ```
 
 ### To configure renderer URL

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 server { 
- listen 80;
+ listen 8080;
  server_name mermaid;
  location / {
    root /usr/share/nginx/html;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Use 8080 as default port to reduce privilege requirements as any port lower than 1024 require root, even in unprivileged nginx 

Resolves #1230

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
