### PR TITLE
Use current theme's background color on PNG export

### DIFF
--- a/src/lib/components/Actions.svelte
+++ b/src/lib/components/Actions.svelte
@@ -49,7 +49,7 @@
     if (!context) {
       throw new Error('context not found');
     }
-    context.fillStyle = 'white';
+    context.fillStyle = `hsl(${window.getComputedStyle(document.body).getPropertyValue('--b1')})`;
     context.fillRect(0, 0, canvas.width, canvas.height);
 
     const image = new Image();


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR uses the current selected page theme as the background colour on PNG exports, making text readable on dark themes.

Resolves #1181 

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable:

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
