### PR TITLE
Fix broken link to the tutorial page

### DIFF
--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -29,7 +29,7 @@
     },
     {
       title: 'Tutorial',
-      href: 'https://mermaid.js.org/config/Tutorials.html'
+      href: 'https://mermaid.js.org/ecosystem/tutorials.html'
     },
     {
       title: 'Mermaid',


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix the broken link for the "Tutorial" item in the main menu of the live editor.

## :straight_ruler: Design Decisions

The [tutorial page](https://mermaid.js.org/ecosystem/tutorials.html) is nicer than a [404 page](https://mermaid.js.org/config/Tutorials.html) :wink: 

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
