### PR TITLE
Fix Link to contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,6 @@ Describe the way your implementation works or what design decisions you made if 
 
 Make sure you
 
-- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
+- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
 - [ ] :computer: have added unit/e2e tests (if appropriate)
 - [ ] :bookmark: targeted `develop` branch


### PR DESCRIPTION
The linked markdown file in the github repository only contains the path to the actual file with the guidelines. Furthermore, there is a rendered version on the website, which shows the diagramms and not the code of them.

## :bookmark_tabs: Summary

Fix the link to the contribution guidelines for the pull request template, so that the page at the online documentation is the target.

## :straight_ruler: Design Decisions

A [rendered web page](https://mermaid.js.org/community/contributing.html) is nicer than a [path](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md) or the [markdown](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/docs/community/contributing.md) which is at this path .

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/master/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
