### PR TITLE
fix: subscripts in corner safari, resolves #1423

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -8,3 +8,8 @@
 .action-btn {
   @apply btn btn-primary;
 }
+#graph-div sub,
+#graph-div sup {
+  position: initial;
+  vertical-align: revert;
+}


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes the problem where `sup` and `sub` tags were bunched in a corner in Safari.

Resolves #1423

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable:

The problem was that a `position: relative` and `vertical-align: baseline` was being applied into all `sub`/`sup` tags. The solution was to simply revert these styles.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
