### PR TITLE
fix: stop returning when err so diagram can be rendered post error fix

### DIFF
--- a/src/lib/components/View.svelte
+++ b/src/lib/components/View.svelte
@@ -64,7 +64,6 @@
     if (state.error !== undefined) {
       error = true;
       errorLines = state.error.toString().split('\n');
-      return;
     }
     error = false;
     try {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently in production if for any reason an error occurs, the diagram gets stuck and isn't rendered even after error is fixed hence I have fixed that in this PR

eg, try with below code and config in prod vs this PR
```
flowchart TD
    A[Christmas] -->|Get money| B(Go shopping)
    B --> C{Let me think}
    C -->|One| D[Laptop]
    C -->|Two| E[iPhone]
    C -->|Three| F[fa:fa-car Car]
  ```
  
  ```
  {
  "theme": "default",
  "maxEdges": "10"
```

change the config to `2` and change it back to `10` -> In prod the diagrams will not rerender until refresh.

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
