### PR TITLE
Preventing requests to the AnalyticsURL if it is not set

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-  MERMAID_DOMAIN="mermaid.live"
-	MERMAID_ANALYTICS_URL="https://p.mermaid.live"
+MERMAID_DOMAIN=""
+MERMAID_ANALYTICS_URL=""

--- a/src/lib/util/stats.ts
+++ b/src/lib/util/stats.ts
@@ -4,6 +4,10 @@ import { env } from './env';
 export let plausible: ReturnType<typeof PlausibleInstance> | undefined;
 
 export const initAnalytics = async (): Promise<void> => {
+  if (env.analyticsUrl.length === 0) {
+    return;
+  }
+
   if (browser && !plausible) {
     try {
       const { default: Plausible } = await import('plausible-tracker');


### PR DESCRIPTION
## :bookmark_tabs: Summary

I noticed that my self-hosted Mermaid Live Editor is sending requests to the analytics URL when I didn't set the analytics URL and the mermaid domain, and I believe it should be configured according to the instructions provided in the https://github.com/mermaid-js/mermaid-live-editor?tab=readme-ov-file#to-configure-analytics.

My expectation is that the Mermaid Live Editor should not be sending requests to the analytics URL because, according to the README, the default setting is empty, which disables analytics.

Therefore, I would like to make changes to address this issue.

Brief description about the content of your PR:

- Default env value is empty.
- Prevent to request to mermaid.live for analytics if analyticsURL is not set.
- analytics information is better to be empty because of default behavior at [README](https://github.com/mermaid-js/mermaid-live-editor?tab=readme-ov-file#to-configure-analytics)



Resolves #<your issue id here>

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable:

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
