### PR TITLE
feat: Support jsonSchema to validate config

### DIFF
--- a/src/lib/components/DesktopEditor.svelte
+++ b/src/lib/components/DesktopEditor.svelte
@@ -21,6 +21,17 @@
   } satisfies monaco.editor.IStandaloneEditorConstructionOptions;
   let currentText = '';
 
+  const jsonModel = monaco.editor.createModel(
+    '',
+    'json',
+    monaco.Uri.parse('internal://config.json')
+  );
+  const mermaidModel = monaco.editor.createModel(
+    '',
+    'mermaid',
+    monaco.Uri.parse('internal://mermaid.mmd')
+  );
+
   onMount(() => {
     self.MonacoEnvironment = {
       getWorker(_, label) {
@@ -34,6 +45,17 @@
     if (!divElement) {
       throw new Error('divEl is undefined');
     }
+
+    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+      validate: true,
+      enableSchemaRequest: true,
+      schemas: [
+        {
+          fileMatch: ['config.json'],
+          uri: 'https://mermaid.js.org/schemas/config.schema.json'
+        }
+      ]
+    });
 
     initEditor(monaco);
     errorDebug();
@@ -52,23 +74,18 @@
         return;
       }
 
+      const model = editorMode === 'code' ? mermaidModel : jsonModel;
+
+      if (editor.getModel()?.id !== model.id) {
+        editor.setModel(model);
+      }
+
       // Update editor text if it's different
       const newText = editorMode === 'code' ? code : mermaid;
       if (newText !== currentText) {
         editor.setScrollTop(0);
         editor.setValue(newText);
         currentText = newText;
-      }
-
-      // Update editor mode if it's different
-      const language = editorMode === 'code' ? 'mermaid' : 'json';
-      const model = editor.getModel();
-      if (!model) {
-        console.error("editor model doesn't exist");
-        return;
-      }
-      if (model.getLanguageId() !== language) {
-        monaco.editor.setModelLanguage(model, language);
       }
 
       // Display/clear errors


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds JSONSchema support to validate and provide auto completions for mermaid config.

<img width="547" alt="image" src="https://github.com/user-attachments/assets/e6522122-8965-4036-bb50-ef8a52908338" />

<img width="579" alt="image" src="https://github.com/user-attachments/assets/4cd6c635-7a0c-4a25-81f5-369981ab5630" />

<img width="579" alt="image" src="https://github.com/user-attachments/assets/6526c22b-4850-4cc7-bbd7-0c5aadd92789" />

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable:

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :bookmark: targeted `develop` branch
