### PR TITLE
ci(docker-publish): add arm64 builds and attestations

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,11 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -39,6 +44,7 @@ jobs:
           tags: |
             type=raw,value=${{ env.RELEASE_VERSION }}
       - uses: docker/build-push-action@v5
+        id: build
         with:
           context: .
           target: mermaid
@@ -47,3 +53,9 @@ jobs:
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate Build Attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,16 +33,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get release version
-        run: |
-          RELEASE_VERSION=$([ "${{ github.ref_name }}" = "master" ] && echo "latest" || echo "nightly")
-          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_ENV}"
       - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=${{ env.RELEASE_VERSION }}
+            type=raw,value=latest,enable=${{ github.ref_name == "master" }}
+            type=raw,value=nightly,enable=${{ github.ref_name == "develop" }}
       - uses: docker/build-push-action@v5
         id: build
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -59,3 +59,4 @@ jobs:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+        if: github.event_name == 'push'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,6 +43,7 @@ jobs:
           context: .
           target: mermaid
           push: ${{ github.event_name == 'push' }}
+          platforms: linux/amd64,linux/arm64
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## :bookmark_tabs: Summary

add arm64 builds and attestations. these builds do take a good bit longer, during my tests they were around 15 mins. hope that's okay. There's a more complex solution with building them in a matrix using different runners. I have done this for this project: https://github.com/lukevella/rallly/pull/1783 because the run time exceeded acceptable amounts otherwise and got timed out.

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable:

- usually running on `arm64` is cheaper
- adding attestations increases security by providing provenance.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [X] :computer: have added unit/e2e tests (if appropriate)
- [X] :bookmark: targeted `develop` branch
