### PR TITLE
fix: light background with dark diagram theme when downloading SVG ([#1777](https://github.com/mermaid-js/mermaid-live-editor/issues/1777))

### DIFF
--- a/src/lib/components/Actions.svelte
+++ b/src/lib/components/Actions.svelte
@@ -45,6 +45,8 @@
       svg = getSvgElement();
     }
 
+    svg.style.backgroundColor = `hsl(${window.getComputedStyle(document.body).getPropertyValue('--background')})`;
+
     const svgString = svg.outerHTML
       .replaceAll('<br>', '<br/>')
       .replaceAll(/<img([^>]*)>/g, (m, g: string) => `<img ${g} />`);


### PR DESCRIPTION


## :bookmark_tabs: Summary

Brief description about the content of your PR: 

Adds the background color for legibility for SVG downloads in dark theme, in the same way the background color is added when downloading PNG in `exportImage`

Resolves #1777

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable:

As CSS and `bacgkround-color` property is already used in exported SVG in the `<style>` element for `<svg>` children, using  

```js
svg.style.backgroundColor = `hsl(${window.getComputedStyle(document.body).getPropertyValue('--background')})`;`

```

 for the `<svg>` element itself is appopriate.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
