### PR TITLE
fix(export): Remove redundant hsl() from background color

### DIFF
--- a/src/lib/components/Actions.svelte
+++ b/src/lib/components/Actions.svelte
@@ -50,7 +50,7 @@
       svg = getSvgElement();
     }
 
-    svg.style.backgroundColor = `hsl(${window.getComputedStyle(document.body).getPropertyValue('--background')})`;
+    svg.style.backgroundColor = window.getComputedStyle(document.body).getPropertyValue('--background');
 
     const svgString = svg.outerHTML
       .replaceAll('<br>', '<br/>')
@@ -100,7 +100,7 @@ ${svgString}`);
       throw new Error('context not found');
     }
 
-    context.fillStyle = `hsl(${window.getComputedStyle(document.body).getPropertyValue('--background')})`;
+    context.fillStyle = window.getComputedStyle(document.body).getPropertyValue('--background');
     context.fillRect(0, 0, canvas.width, canvas.height);
 
     const image = new Image();


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes an issue where exported Images have an incorrect background color.
   - Copied Image incorrectly had a black background.
   - Downloaded SVGs incorrectly had a white background.
This change ensures that the background color of the exported SVG respects the current theme of the editor.

Resolves #1797 

## :straight_ruler: Design Decisions

The code incorrectly wrapped a color value from a CSS variable with an hsl() function, creating an invalid color. The fix removes the redundant hsl() wrapper, ensuring the background color value from the CSS variable is used directly and correctly.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
