### PR TITLE
fix: ensure CJK text visibility in SVG export 

### DIFF
--- a/src/lib/components/Actions.svelte
+++ b/src/lib/components/Actions.svelte
@@ -60,11 +60,6 @@
   const getSvgElement = () => {
     const svgElement = document.querySelector('#container svg')?.cloneNode(true) as HTMLElement;
     svgElement.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
-
-    if ($stateStore.rough) {
-      fixForeignObjectClipping(svgElement);
-    }
-
     return svgElement;
   };
 
@@ -83,6 +78,10 @@
 
     if (!svg) {
       svg = getSvgElement();
+    }
+
+    if ($stateStore.rough) {
+      fixForeignObjectClipping(svg);
     }
 
     svg.style.backgroundColor = window

--- a/src/lib/components/Actions.svelte
+++ b/src/lib/components/Actions.svelte
@@ -28,57 +28,32 @@
     `mermaid-diagram-${dayjs().format('YYYY-MM-DD-HHmmss')}.${extension}`;
 
   /**
-   * Fix text visibility issues in exported SVG.
-   * Handles <text> elements and <foreignObject> elements (Mermaid's text containers).
+   * Fix text clipping in exported SVG for hand-drawn (rough) mode.
+   * svg2roughjs copies foreignObject elements but their height is often insufficient,
+   * causing text bottom edges to be cut off regardless of language.
    */
-  const ensureTextVisibility = (svg: HTMLElement) => {
-    const textElements = svg.querySelectorAll('text, tspan');
+  const fixForeignObjectClipping = (svg: HTMLElement) => {
     const foreignObjects = svg.querySelectorAll('foreignObject');
-
-    // Fix <text> elements with CJK characters
-    textElements.forEach((el) => {
-      if (el.getAttribute('data-text-fixed') === 'true') {
-        return;
-      }
-
-      const text = el.textContent || '';
-      const hasCJK = /[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/.test(text);
-
-      if (hasCJK) {
-        el.setAttribute('dominant-baseline', 'middle');
-        el.setAttribute('data-text-fixed', 'true');
-      }
-    });
-
-    // Fix <foreignObject> elements (Mermaid's primary text containers)
     foreignObjects.forEach((foreignObj) => {
-      const content = foreignObj.textContent || '';
-      const hasCJK = /[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/.test(content);
+      const currentHeight = parseFloat(foreignObj.getAttribute('height') || '0');
+      if (currentHeight <= 0) return;
 
-      if (hasCJK) {
-        // Increase foreignObject height to prevent CJK text clipping
-        const currentHeight = parseFloat(foreignObj.getAttribute('height') || '24');
-        const currentY = parseFloat(foreignObj.getAttribute('y') || '0');
-        const newHeight = currentHeight * 1.5;
+      const currentY = parseFloat(foreignObj.getAttribute('y') || '0');
+      const newHeight = currentHeight * 1.5;
+      const heightDiff = newHeight - currentHeight;
 
-        // Adjust y coordinate to compensate for height increase, keeping text visually centered
-        const heightDiff = newHeight - currentHeight;
-        const newY = currentY - heightDiff / 2;
+      foreignObj.setAttribute('height', newHeight.toString());
+      foreignObj.setAttribute('y', (currentY - heightDiff / 2).toString());
 
-        foreignObj.setAttribute('height', newHeight.toString());
-        foreignObj.setAttribute('y', newY.toString());
-
-        // Apply vertical centering styles to inner HTML elements
-        const htmlElements = foreignObj.querySelectorAll('div, span, p');
-        htmlElements.forEach((htmlEl) => {
-          const el = htmlEl as HTMLElement;
-          el.style.display = 'flex';
-          el.style.alignItems = 'center';
-          el.style.justifyContent = 'center';
-          el.style.height = '100%';
-          el.style.lineHeight = '1.2';
-        });
-      }
+      // Ensure inner HTML elements are vertically centered within the expanded area
+      const htmlElements = foreignObj.querySelectorAll('div, span, p');
+      htmlElements.forEach((htmlEl) => {
+        const el = htmlEl as HTMLElement;
+        el.style.display = 'flex';
+        el.style.alignItems = 'center';
+        el.style.justifyContent = 'center';
+        el.style.height = '100%';
+      });
     });
   };
 
@@ -86,9 +61,8 @@
     const svgElement = document.querySelector('#container svg')?.cloneNode(true) as HTMLElement;
     svgElement.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
 
-    // Ensure CJK text visibility in hand-drawn (rough) mode export
     if ($stateStore.rough) {
-      ensureTextVisibility(svgElement);
+      fixForeignObjectClipping(svgElement);
     }
 
     return svgElement;

--- a/src/lib/components/Actions.svelte
+++ b/src/lib/components/Actions.svelte
@@ -117,18 +117,25 @@ ${svgString}`);
 
     const box = svg.getBoundingClientRect();
 
+    // In rough mode, SVG has width/height="100%" so getBoundingClientRect returns
+    // the container size, not the actual diagram size. Use viewBox dimensions instead.
+    const svgEl = svg as unknown as SVGSVGElement;
+    const viewBox = svgEl.viewBox?.baseVal;
+    const contentWidth = viewBox && viewBox.width > 0 ? viewBox.width : box.width;
+    const contentHeight = viewBox && viewBox.height > 0 ? viewBox.height : box.height;
+
     if (imageSizeMode === 'width') {
-      const ratio = box.height / box.width;
+      const ratio = contentHeight / contentWidth;
       canvas.width = imageSize;
       canvas.height = imageSize * ratio;
     } else if (imageSizeMode === 'height') {
-      const ratio = box.width / box.height;
+      const ratio = contentWidth / contentHeight;
       canvas.width = imageSize * ratio;
       canvas.height = imageSize;
     } else {
       const multiplier = 2;
-      canvas.width = box.width * multiplier;
-      canvas.height = box.height * multiplier;
+      canvas.width = contentWidth * multiplier;
+      canvas.height = contentHeight * multiplier;
     }
 
     const context = canvas.getContext('2d');


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix CJK (Chinese, Japanese, Korean) text clipping and misalignment in SVG/PNG exports when using hand-drawn (rough) mode.

Resolves #1885

## :straight_ruler: Design Decisions

When hand-drawn mode is enabled, `svg2roughjs` re-renders the SVG into a sketch-style output. During this conversion, CJK text inside `<foreignObject>` elements can get clipped or misaligned due to insufficient container height.

This PR adds an `ensureTextVisibility` post-processing step that runs only in rough mode during export:

1. For `<text>`/`<tspan>` elements containing CJK characters, sets `dominant-baseline` to `middle` to fix vertical alignment.
2. For `<foreignObject>` elements containing CJK characters:
   - Increases the container height by 50% to prevent clipping.
   - Adjusts the `y` coordinate to keep text visually centered.
   - Applies flexbox centering styles to inner HTML elements.

The fix is scoped to rough mode only, since normal mode renders CJK text correctly.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch

![mermaid-diagram-2026-02-15-174831](https://github.com/user-attachments/assets/9262de58-b1a8-4486-928a-679545f4a77e)