### PR TITLE
feat: add Use Case diagram to sample diagrams and documentation

### DIFF
--- a/src/lib/components/DiagramDocumentationButton.svelte
+++ b/src/lib/components/DiagramDocumentationButton.svelte
@@ -82,6 +82,10 @@
       code: '/syntax/treemap.html',
       config: '/syntax/treemap.html#configuration-options'
     },
+    usecase: {
+      code: '/syntax/usecase.html',
+      config: '/syntax/usecase.html#configuration'
+    },
     xychart: {
       code: '/syntax/xyChart.html',
       config: '/syntax/xyChart.html#chart-configurations'

--- a/src/lib/components/Preset.svelte
+++ b/src/lib/components/Preset.svelte
@@ -7,6 +7,14 @@
   import ShapesIcon from '~icons/material-symbols/account-tree-outline-rounded';
 
   const extras = {
+    'Use Case': `usecaseDiagram
+      actor "User" as user
+      package "System" {
+          usecase "Login" as uc1
+          usecase "Logout" as uc2
+      }
+      user --> uc1; uc2
+      `,
     ZenUML: `zenuml
     title Order Service
     @Actor Client #FFEBE6


### PR DESCRIPTION
## Description
This PR adds the "Use Case" diagram to the Live Editor, allowing users to discover and test the new syntax easily.

## Changes
- Added `Use Case` sample code to `src/lib/components/Preset.svelte` within the `extras` object.
- Mapped the documentation link in `src/lib/components/DiagramDocumentationButton.svelte` to `/syntax/usecase.html`.

## Related Issues
Relates to core Mermaid PR: mermaid-js/mermaid#7569 (Use Case Diagram Implementation)

## Note to Maintainers
The documentation link will point to a 404 until the main Mermaid site is rebuilt with the new syntax docs. This is intended to ensure functionality once the core release is live.