### PR TITLE
Feat/openshift helm chart

### DIFF
--- a/openshift/Chart.yaml
+++ b/openshift/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: mermaid
+description: >
+  A Helm chart for deploying the Mermaid Live Editor on OpenShift.
+  Produces diagrams and charts from plain-text Mermaid syntax.
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - mermaid
+  - diagrams
+  - charts
+  - visualization
+home: https://mermaid.js.org
+sources:
+  - https://github.com/mermaid-js/mermaid-live-editor

--- a/openshift/LICENSE
+++ b/openshift/LICENSE
@@ -1,0 +1,40 @@
+MIT License
+
+© His Majesty the King in Right of Canada, as represented by the Minister of
+Agriculture and Agri-Food Canada, 2026.
+
+© Sa Majesté le Roi du chef du Canada, représentée par le ministre de
+l'Agriculture et Agroalimentaire Canada, 2026.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+English
+
+Deployed applications are obtained from their respective upstream projects and
+are governed by their own, separate licenses, including but not limited to
+permissive, copyleft (GPL/AGPL), and proprietary licenses.
+
+Français
+
+Les applications déployées sont obtenues à partir de leurs projets amont
+respectifs et sont régies par leurs propres licences distinctes, y compris,
+sans s'y limiter, des licences permissives, à copyleft (GPL/AGPL) et
+propriétaires.

--- a/openshift/NOTICE
+++ b/openshift/NOTICE
@@ -1,0 +1,52 @@
+-------------------------------------------------------------------------------
+Crown Copyright and Upstream Licensing
+Droit d'auteur de la Couronne et licences en amont
+-------------------------------------------------------------------------------
+
+English
+
+Contributions produced by GC and submitted to upstream open-source application
+repositories are provided under the licence of the upstream repository, in
+accordance with its contribution and governance model.
+
+Notwithstanding the above, Crown copyright is retained for the portions of code
+authored by public servants, in the form and state in which those contributions
+are submitted.
+
+This retention does not restrict or alter the rights granted to users under the
+applicable upstream open-source licence.
+
+Français
+
+Les contributions produites par le GC et soumises à des dépôts d'applications
+open source en amont sont diffusées sous la licence du dépôt en amont,
+conformément à ses règles de contribution et de gouvernance.
+
+Nonobstant ce qui précède, le droit d'auteur de la Couronne est conservé pour
+les portions de code rédigées par des fonctionnaires, dans la forme et l'état
+dans lesquels ces contributions sont soumises.
+
+Cette conservation n'a pas pour effet de restreindre ou de modifier les droits
+accordés aux utilisateurs par la licence open source en amont applicable.
+
+-------------------------------------------------------------------------------
+
+English
+
+Portions of this code were authored by the Government of Canada. These
+components, in the form contributed by the GC, are © His Majesty the King in
+Right of Canada, as represented by the Department of Agriculture and Agri-Food
+Canada. This attribution does not modify or replace the applicable licence,
+does not affect permissions, conditions, or disclaimers, and does not
+constitute an endorsement by the Government of Canada of the software, the
+repository, or any deployed application.
+
+Français
+
+Certaines portions de ce code ont été rédigées par le gouvernement du Canada.
+Ces composantes, dans la forme contribuée par le GC, sont © Sa Majesté le Roi
+du chef du Canada, représenté par le ministère de l'Agriculture et
+Agroalimentaire Canada. Cette mention ne modifie ni ne remplace la licence
+applicable, n'affecte pas les autorisations, conditions ou limitations de
+responsabilité, et ne constitue pas une approbation du logiciel, du dépôt ou
+des applications déployées par le gouvernement du Canada.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,45 @@
+# mermaid — Helm Chart for OpenShift
+
+Deploys the [Mermaid Live Editor](https://github.com/mermaid-js/mermaid-live-editor) on an OpenShift cluster.
+
+## Prerequisites
+
+- OpenShift 4.x (OCP or OKD)
+- Helm 3.x
+- `oc` CLI logged in with `edit` permissions on the target namespace
+
+## Installation
+
+```bash
+# Create a project (namespace) - skip if using an existing namespace
+oc new-project <namespace>
+
+# Install with defaults (Route enabled, TLS edge)
+# In the directory where Chart.yaml is located
+helm install mermaid . -n <namespace>
+```
+
+## Upgrade
+
+```bash
+helm upgrade mermaid .-n <namespace>
+```
+
+## Uninstall
+
+```bash
+helm uninstall mermaid -n <namespace>
+```
+
+## Troubleshooting
+
+```bash
+# Check SCC assignment
+oc get pod -n <namespace> -o jsonpath='{.items[*].metadata.annotations.openshift\.io/scc}'
+
+# Describe the route
+oc describe route mermaid -n <namespace>
+
+# View events
+oc get events -n <namespace> --sort-by='.lastTimestamp'
+```

--- a/openshift/templates/_helpers.tpl
+++ b/openshift/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mermaid.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "mermaid.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label (used in selector labels).
+*/}}
+{{- define "mermaid.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to every resource.
+*/}}
+{{- define "mermaid.labels" -}}
+helm.sh/chart: {{ include "mermaid.chart" . }}
+{{ include "mermaid.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels — used by Service and Deployment matchLabels.
+*/}}
+{{- define "mermaid.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mermaid.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "mermaid.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mermaid.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolved image tag — falls back to Chart.AppVersion.
+*/}}
+{{- define "mermaid.imageTag" -}}
+{{- .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}

--- a/openshift/templates/configmap.yaml
+++ b/openshift/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.appConfig -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mermaid.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mermaid.labels" . | nindent 4 }}
+data:
+  app.config.json: |
+    {{ .Values.appConfig | toJson | nindent 4 }}
+{{- end }}

--- a/openshift/templates/deployment.yaml
+++ b/openshift/templates/deployment.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mermaid.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mermaid.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mermaid.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mermaid.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mermaid.serviceAccountName" . }}
+
+      # ----------------------------------------------------------------
+      # Pod-level security context
+      # Compatible with OpenShift's 'restricted' SCC.
+      # OpenShift will inject the runAsUser/fsGroup from the SCC range —
+      # do NOT hard-code UIDs here so the SCC can manage them.
+      # ----------------------------------------------------------------
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+
+      containers:
+        - name: mermaid
+          image: "{{ .Values.image.repository }}:{{ include "mermaid.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          # --------------------------------------------------------------
+          # Container-level security context
+          # --------------------------------------------------------------
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+
+          # --------------------------------------------------------------
+          # Environment variables
+          # --------------------------------------------------------------
+          env:
+            - name: NODE_ENV
+              value: "production"
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+          # --------------------------------------------------------------
+          # Probes
+          # --------------------------------------------------------------
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+
+          # --------------------------------------------------------------
+          # Resources
+          # --------------------------------------------------------------
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+          # --------------------------------------------------------------
+          # Volume mounts
+          # readOnlyRootFilesystem: true requires writable tmp dirs.
+          # --------------------------------------------------------------
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            # Nginx requires writable cache and pid dirs.
+            # readOnlyRootFilesystem: true blocks these without emptyDir mounts.
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            # NOTE: do NOT mount over /etc/nginx/conf.d — the image bakes in
+            # default.conf there. An emptyDir would wipe it and Nginx would exit
+            # cleanly with no site config (SIGQUIT/exit 0 restart loop).
+            # The entrypoint warning "can not modify default.conf" is harmless.
+            {{- if .Values.appConfig }}
+            - name: app-config
+              mountPath: /app/config
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+      # ----------------------------------------------------------------
+      # Volumes
+      # ----------------------------------------------------------------
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        {{- if .Values.appConfig }}
+        - name: app-config
+          configMap:
+            name: {{ include "mermaid.fullname" . }}-config
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/openshift/templates/networkpolicy.yaml
+++ b/openshift/templates/networkpolicy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.networkPolicy.enabled -}}
+# Allow inbound traffic only from the OpenShift router pods (in the
+# openshift-ingress namespace) and from within the same namespace.
+# Adjust the namespaceSelector label if your router lives elsewhere.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mermaid.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mermaid.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mermaid.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow traffic from OpenShift router pods
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-ingress
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+    # Allow traffic from within the same namespace (e.g. other micro-services)
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+{{- end }}

--- a/openshift/templates/route.yaml
+++ b/openshift/templates/route.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.route.enabled -}}
+# OpenShift Route — preferred over Kubernetes Ingress on OCP clusters.
+# Supports edge, reencrypt, and passthrough TLS termination natively.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "mermaid.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mermaid.labels" . | nindent 4 }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  path: {{ .Values.route.path }}
+  to:
+    kind: Service
+    name: {{ include "mermaid.fullname" . }}
+    weight: 100
+  port:
+    targetPort: http
+  {{- if .Values.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/openshift/templates/service.yaml
+++ b/openshift/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mermaid.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mermaid.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "mermaid.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/openshift/templates/serviceaccount.yaml
+++ b/openshift/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mermaid.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mermaid.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/openshift/values.yaml
+++ b/openshift/values.yaml
@@ -1,0 +1,138 @@
+# -----------------------------------------------------------------------
+# Mermaid Live Editor — Helm values for OpenShift
+# -----------------------------------------------------------------------
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mermaid-js/mermaid-live-editor
+  pullPolicy: Always
+  # Overrides the image tag. Defaults to Chart.appVersion when empty.
+  tag: ""
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# -----------------------------------------------------------------------
+# ServiceAccount
+# OpenShift uses SCCs instead of PodSecurityPolicies. Binding the SA
+# to the 'restricted' SCC (the default) is the right posture for most
+# workloads. Adjust if your cluster has a custom SCC.
+# -----------------------------------------------------------------------
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# -----------------------------------------------------------------------
+# Pod security — OpenShift 'restricted' SCC compatible:
+#   • runAsNonRoot: true
+#   • no privilege escalation
+#   • drop ALL capabilities
+#   • read-only root filesystem (writable emptyDir mounts where needed)
+# -----------------------------------------------------------------------
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+
+# -----------------------------------------------------------------------
+# Container port
+# The mermaid-live-editor listens on 8080 (non-root-friendly).
+# -----------------------------------------------------------------------
+service:
+  type: ClusterIP
+  port: 8080
+  targetPort: 8080
+
+# -----------------------------------------------------------------------
+# OpenShift Route (preferred over Ingress on OCP)
+# Set route.enabled: true and ingress.enabled: false for OpenShift.
+# -----------------------------------------------------------------------
+route:
+  enabled: true
+  host: ""           # e.g. mermaid.apps.cluster.example.com  (auto-assigned if empty)
+  path: /
+  tls:
+    enabled: true
+    termination: edge          # edge | reencrypt | passthrough
+    insecureEdgeTerminationPolicy: Redirect   # Redirect | Allow | None
+  annotations: {}
+
+# -----------------------------------------------------------------------
+# Resources — tune for your cluster sizing
+# -----------------------------------------------------------------------
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# -----------------------------------------------------------------------
+# Probes
+# -----------------------------------------------------------------------
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 20
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+# -----------------------------------------------------------------------
+# Node scheduling
+# -----------------------------------------------------------------------
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -----------------------------------------------------------------------
+# Additional environment variables passed to the container
+# -----------------------------------------------------------------------
+env: []
+# - name: MERMAID_RENDERER_URL
+#   value: https://kroki.io
+
+# -----------------------------------------------------------------------
+# Extra volumes / mounts (e.g. for custom CA certs)
+# -----------------------------------------------------------------------
+extraVolumes: []
+extraVolumeMounts: []
+
+# -----------------------------------------------------------------------
+# NetworkPolicy — restricts ingress to the OpenShift router pods only
+# -----------------------------------------------------------------------
+networkPolicy:
+  enabled: true
+
+# -----------------------------------------------------------------------
+# ConfigMap — optional custom mermaid app config (JSON)
+# Leave appConfig empty to skip the ConfigMap entirely.
+# -----------------------------------------------------------------------
+appConfig: {}
+# Example:
+# appConfig:
+#   securityLevel: "strict"
+#   theme: "default"


### PR DESCRIPTION
## Add OpenShift Helm Chart

This PR adds a Helm chart for deploying the Mermaid Live Editor on OpenShift clusters (OCP/OKD 4.x).

This chart was created as part of an experimental run of migrating applications to the OpenShift platform for Agriculture and Agri-Food Canada, and thought it may be helpful to contribute the developed chart for others who may be doing something similar. Please feel free to reorganize/restructure these contributions to best fit the project

### What's included

A self-contained chart under `openshift/` with the following templates:

- `deployment.yaml` — standard Deployment with OpenShift-compatible security context
- `service.yaml` — ClusterIP on port 8080
- `route.yaml` — OpenShift `Route` with TLS edge termination (conditional, enabled by default)
- `networkpolicy.yaml` — restricts ingress to the OpenShift router namespace (conditional)
- `serviceaccount.yaml` — dedicated SA with `automountServiceAccountToken: false`
- `configmap.yaml` — optional JSON app config mount

### OpenShift-specific design decisions

**Security context** — compatible with the `restricted` SCC out of the box:
- `runAsNonRoot: true` with no hard-coded UID (OpenShift injects from the project range)
- `readOnlyRootFilesystem: true` with `emptyDir` mounts for `/tmp`, `/var/cache/nginx`, and `/var/run`
- `allowPrivilegeEscalation: false`, `capabilities: drop: [ALL]`
- `seccompProfile: RuntimeDefault`

**Route over Ingress** — uses `route.openshift.io/v1` which is the native exposure mechanism on OCP. The `route.enabled` value defaults to `true` and can be disabled for non-OCP clusters.

**NetworkPolicy** — scoped to allow ingress only from pods in the `openshift-ingress` namespace (the HAProxy router) and same-namespace peers.

### Usage

```bash
# Install
oc new-project mermaid
helm install mermaid ./openshift -n mermaid

# Upgrade
helm upgrade mermaid ./openshift -n mermaid

# Uninstall
helm uninstall mermaid -n mermaid
```

### License

Portions of this code were authored by the Government of Canada. These components in the form contributed by the GC are © His Majesty the King in Right of Canada, as represented by the Minister of Agriculture and Agri-Food Canada, 2026. This attribution does not modify or replace the applicable licence, does not affect permissions, conditions, or disclaimers, and does not constitute an endorsement by the Government of Canada of the software, the repository, or any deployed application.

A `LICENSE` file is included under `openshift/` for reference.