### PR TITLE
fix(#1961): Correct favicon link tags

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -8,7 +8,9 @@
     <meta
       name="description"
       content="Simplify documentation and avoid heavy tools. Open source Visio Alternative. Commonly used for explaining your code! Mermaid is a simple markdown-like script language for generating charts from text via javascript." />
-    <link rel="icon" type="image/png" href="%sveltekit.assets%/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
+    <link rel="icon" type="image/x-icon" href="%sveltekit.assets%/favicon.ico" />
+    <link rel="apple-touch-icon" href="%sveltekit.assets%/favicon.png" />
     <link rel="mask-icon" href="%sveltekit.assets%/favicon.svg" color="#000000" />
     <meta name="theme-color" content="#ff3670" />
     <link rel="manifest" href="%sveltekit.assets%/manifest.json" />

--- a/src/app.html
+++ b/src/app.html
@@ -9,7 +9,6 @@
       name="description"
       content="Simplify documentation and avoid heavy tools. Open source Visio Alternative. Commonly used for explaining your code! Mermaid is a simple markdown-like script language for generating charts from text via javascript." />
     <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
-    <link rel="icon" type="image/x-icon" href="%sveltekit.assets%/favicon.ico" />
     <link rel="apple-touch-icon" href="%sveltekit.assets%/favicon.png" />
     <link rel="mask-icon" href="%sveltekit.assets%/favicon.svg" color="#000000" />
     <meta name="theme-color" content="#ff3670" />


### PR DESCRIPTION
## :bookmark_tabs: Summary

Three small markup fixes in `src/app.html`:

- Update the icon link's `type` from `image/png` to `image/svg+xml` so it matches its `favicon.svg` href.
- Add an explicit `image/x-icon` link for `favicon.ico` (previously discoverable only via the root `/favicon.ico` auto-probe).
- Add an `apple-touch-icon` link pointing at `favicon.png` (512×512), so iOS "Add to Home Screen" uses the Mermaid logo instead of a low-quality page screenshot.

Resolves #1961

## :straight_ruler: Design Decisions

- The MIME mismatch was introduced in #1065 when the href was switched from `.png` to `.svg` without updating `type`. Browsers ignore the attribute and trust the response Content-Type, so this was never user-visible — just incorrect markup.
- `apple-touch-icon` reuses the existing `static/favicon.png` (512×512) rather than introducing a new asset. iOS scales it appropriately for all touch-icon sizes.
- No `sizes` attribute is set on the touch-icon link; iOS Safari is happy to pick the appropriate size from the single 512×512 source.
- No behavior change for existing desktop users; this is markup-only.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added unit/e2e tests (if appropriate) — N/A, markup-only change with no testable behavior delta
- [x] :bookmark: targeted `develop` branch