### PR TITLE
chore: Auto-close issues with only "Broken link" in title

### DIFF
--- a/.github/workflows/close-broken-link-issues.yml
+++ b/.github/workflows/close-broken-link-issues.yml
@@ -1,0 +1,54 @@
+name: Close broken link issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  close-broken-link-issues:
+    if: github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues with only "Broken link" in the title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.issue.title.trim();
+            const isBrokenLinkOnlyTitle = /^broken link\.?$/i.test(title);
+
+            if (!isBrokenLinkOnlyTitle) {
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const newIssueUrl = `https://github.com/${owner}/${repo}/issues/new?assignees=&labels=bug&template=bug_report.md&title=Broken%20link`;
+
+            const commentBody = [
+              `@${context.payload.issue.user.login} This issue was automatically closed because the title only contains "Broken link" without additional details.`,
+              '',
+              'When reporting a broken link, please include:',
+              '- The full URL that failed to load',
+              '- What you expected to happen',
+              '- Any error messages you saw',
+              '',
+              `You can [open a new issue](${newIssueUrl}) with this information.`
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body: commentBody
+            });
+
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              state: 'closed',
+              state_reason: 'not_planned'
+            });

--- a/.github/workflows/close-broken-link-issues.yml
+++ b/.github/workflows/close-broken-link-issues.yml
@@ -27,15 +27,21 @@ jobs:
             const issueNumber = context.payload.issue.number;
             const newIssueUrl = `https://github.com/${owner}/${repo}/issues/new?assignees=&labels=bug&template=bug_report.md&title=Broken%20link`;
 
+            const mermaidIssuesUrl = 'https://github.com/mermaid-js/mermaid/issues/new';
+
             const commentBody = [
               `@${context.payload.issue.user.login} This issue was automatically closed because the title only contains "Broken link" without additional details.`,
               '',
-              'When reporting a broken link, please include:',
+              '**Please only open issues here if something is broken in the live editor itself** (e.g. a link fails to load, the editor UI misbehaves, or a feature of mermaid.live does not work).',
+              '',
+              '**Do not open issues here for syntax errors or invalid Mermaid diagram code.** Those belong in the main Mermaid repository: [mermaid-js/mermaid](https://github.com/mermaid-js/mermaid/issues/new).',
+              '',
+              'If you are reporting a live editor bug, please include:',
               '- The full URL that failed to load',
               '- What you expected to happen',
               '- Any error messages you saw',
               '',
-              `You can [open a new issue](${newIssueUrl}) with this information.`
+              `You can [open a new issue in this repo](${newIssueUrl}) with this information, or report diagram syntax issues in the [Mermaid repo](${mermaidIssuesUrl}).`
             ].join('\n');
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Summary
- Add a GitHub Action that runs on issue open/edit events
- Automatically closes issues whose title is exactly "Broken link" (the default pre-filled title from the live editor error flow)
- Posts a comment asking the reporter to include the failing URL and reproduction details

## Test plan
- [ ] Merge and open a test issue titled `Broken link` — verify it is auto-closed with the explanatory comment
- [ ] Open an issue titled `Broken link: https://mermaid.live/edit#...` — verify it is **not** closed
- [ ] Edit a closed issue title back to `Broken link` — verify the action runs again on `edited`


Made with [Cursor](https://cursor.com)