### PR TITLE
fix: keep diagram documentation links on mermaid.js.org

### DIFF
--- a/src/lib/components/DiagramDocumentationButton.svelte
+++ b/src/lib/components/DiagramDocumentationButton.svelte
@@ -2,12 +2,11 @@
   import { Button } from '$/components/ui/button';
   import { TID } from '$/constants';
   import type { DocumentationConfig } from '$/types';
-  import { env } from '$/util/env';
   import { standardizeDiagramType } from '$/util/mermaid';
   import { validatedState } from '$/util/state.svelte';
   import BookIcon from '~icons/material-symbols/book-2-outline-rounded';
 
-  const docURLBase = env.docsUrl;
+  const docURLBase = 'https://mermaid.js.org';
   const docMap = {
     architecture: {
       code: '/syntax/architecture.html'

--- a/tests/docMap.spec.ts
+++ b/tests/docMap.spec.ts
@@ -6,7 +6,7 @@ test.describe('Editor docs tests', () => {
   });
 
   test('Test default loading', async ({ editPage }) => {
-    await editPage.checkDocURL(/mermaid\.js\.org\//);
+    await editPage.checkDocURL(/^https:\/\/mermaid\.js\.org\//);
   });
 
   test('Test to see if the correct URL loads when changing from one diagram to other', async ({


### PR DESCRIPTION
## Summary

- Keep diagram-specific Docs button links on the Mermaid.js documentation domain
- Prevent MERMAID_DOCS_URL deployment configuration from redirecting diagram docs links to mermaid.ai
- Strengthen the existing documentation URL regression test

## Testing

- pnpm check
- MERMAID_DOCS_URL=https://mermaid.ai pnpm test:e2e tests/docMap.spec.ts

Closes #1955