### PR TITLE
feat: register Iconify icon packs so diagram icons render

### DIFF
--- a/src/lib/util/mermaid.ts
+++ b/src/lib/util/mermaid.ts
@@ -8,6 +8,41 @@ import mermaid from 'mermaid';
 mermaid.registerLayoutLoaders([...elkLayouts, ...tidyTreeLayouts]);
 const init = mermaid.registerExternalDiagrams([zenuml]);
 
+/**
+ * Icon packs for the diagrams that draw icons.
+ *
+ * mermaid ships no icons beyond architecture's five built-ins: everything
+ * else — `logos:aws`, `mdi:database`, an `icon:` on a flowchart node — is
+ * resolved against packs the *host* registers, and the Live Editor registers
+ * none. Every such icon therefore renders as mermaid's "?" placeholder here,
+ * including the ones in the icon documentation's own examples.
+ *
+ * Fetched from the CDN rather than bundled, exactly as
+ * https://mermaid.js.org/config/icons.html describes. A loader runs only when
+ * a diagram actually names its pack, so the download happens on the first
+ * diagram that uses one and never otherwise. If the fetch fails — offline, or
+ * a self-hosted instance with no outbound access — mermaid falls back to the
+ * same placeholder shown today, so nothing regresses.
+ */
+const ICON_PACKS = [
+  'logos',
+  'simple-icons',
+  'mdi',
+  'fa6-solid',
+  'fa6-brands',
+  'carbon',
+  'tabler',
+  'devicon'
+];
+
+mermaid.registerIconPacks(
+  ICON_PACKS.map((name) => ({
+    name,
+    loader: () =>
+      fetch(`https://unpkg.com/@iconify-json/${name}@1/icons.json`).then((res) => res.json())
+  }))
+);
+
 export const render = async (
   config: MermaidConfig,
   code: string,


### PR DESCRIPTION
## The problem

mermaid ships no icons beyond `architecture-beta`'s five built-ins (`cloud`, `database`, `disk`, `internet`, `server`). Every other icon — `logos:aws`, `mdi:database`, an `icon:` on a flowchart node — is resolved against packs **the host registers**, and the Live Editor registers none.

So today, in the Live Editor:

```
architecture-beta
  service a(logos:aws)[AWS]
  service b(server)[Server]
```

`b` renders. `a` renders as mermaid's blue "?" placeholder — as does every icon in the [icon documentation's](https://mermaid.js.org/config/icons.html) own examples, and every icon in a diagram brought here from a tool that does register packs.

## The change

Register eight common Iconify packs with CDN loaders, exactly as the documentation describes:

```ts
mermaid.registerIconPacks(
  ICON_PACKS.map((name) => ({
    name,
    loader: () =>
      fetch(`https://unpkg.com/@iconify-json/${name}@1/icons.json`).then((res) => res.json())
  }))
);
```

`logos`, `simple-icons`, `mdi`, `fa6-solid`, `fa6-brands`, `carbon`, `tabler`, `devicon`.

## Cost

**Nothing until an icon is used.** mermaid calls a loader only when a diagram names that pack, and caches the result — so a session that draws no icons makes no request, and one that uses `logos:` fetches `logos` alone. Nothing is added to the bundle and there is no new dependency.

If a fetch fails — offline, or a self-hosted instance with no outbound access — mermaid falls back to the same "?" placeholder shown today. Nothing regresses.

## Alternatives considered

- **Bundling the packs** (`@iconify-json/*` as dependencies with `import()` loaders) keeps it offline, but `mdi` alone is 3.1 MB and the eight together are far more; a CDN fetch on demand seemed the better trade for a hosted editor. Happy to switch if you would rather not depend on unpkg.
- **A different pack list.** These eight are a guess at what people reach for; glad to trim or extend it.

## Tests

Not included on purpose: the only meaningful assertion is "an icon rendered", which needs a real network fetch and would make CI flaky. Happy to add a Playwright test behind a mock if you would like one.
