### PR TITLE
fix(editor): highlight accented characters in identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "hammerjs": "^2.0.8",
     "js-base64": "3.7.8",
     "lodash-es": "^4.18.1",
-    "mermaid": "^11.16.0",
+    "mermaid": "^11.16.1",
     "mode-watcher": "^1.1.0",
     "monaco-editor": "0.55.1",
     "pako": "2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,13 +40,13 @@ importers:
         version: 1.3.0
       '@mermaid-js/layout-elk':
         specifier: ^0.2.2
-        version: 0.2.2(mermaid@11.16.0)
+        version: 0.2.2(mermaid@11.16.1)
       '@mermaid-js/layout-tidy-tree':
         specifier: ^0.2.2
-        version: 0.2.2(mermaid@11.16.0)
+        version: 0.2.2(mermaid@11.16.1)
       '@mermaid-js/mermaid-zenuml':
         specifier: ^0.2.3
-        version: 0.2.3(mermaid@11.16.0)(yaml@2.9.0)
+        version: 0.2.3(mermaid@11.16.1)(yaml@2.9.0)
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
@@ -63,8 +63,8 @@ importers:
         specifier: ^4.18.1
         version: 4.18.1
       mermaid:
-        specifier: ^11.16.0
-        version: 11.16.0
+        specifier: ^11.16.1
+        version: 11.16.1
       mode-watcher:
         specifier: ^1.1.0
         version: 1.1.0(svelte@5.56.4(@typescript-eslint/types@8.60.1))
@@ -2550,8 +2550,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -4267,21 +4267,21 @@ snapshots:
 
   '@mermaid-js/examples@1.3.0': {}
 
-  '@mermaid-js/layout-elk@0.2.2(mermaid@11.16.0)':
+  '@mermaid-js/layout-elk@0.2.2(mermaid@11.16.1)':
     dependencies:
       d3: 7.9.0
       elkjs: 0.9.3
-      mermaid: 11.16.0
+      mermaid: 11.16.1
 
-  '@mermaid-js/layout-tidy-tree@0.2.2(mermaid@11.16.0)':
+  '@mermaid-js/layout-tidy-tree@0.2.2(mermaid@11.16.1)':
     dependencies:
       d3: 7.9.0
-      mermaid: 11.16.0
+      mermaid: 11.16.1
 
-  '@mermaid-js/mermaid-zenuml@0.2.3(mermaid@11.16.0)(yaml@2.9.0)':
+  '@mermaid-js/mermaid-zenuml@0.2.3(mermaid@11.16.1)(yaml@2.9.0)':
     dependencies:
       '@zenuml/core': 3.49.2(yaml@2.9.0)
-      mermaid: 11.16.0
+      mermaid: 11.16.1
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -6147,7 +6147,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.3

--- a/src/lib/util/monacoExtra.test.ts
+++ b/src/lib/util/monacoExtra.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { initEditor } from './monacoExtra';
+
+interface MonarchRule {
+  cases?: Record<string, string>;
+}
+type MonarchAction = string | string[] | MonarchRule;
+interface Grammar {
+  tokenizer: Record<string, [RegExp | string, MonarchAction][]>;
+}
+
+const noop = () => undefined;
+
+/** The Monarch grammar that {@link initEditor} registers for the `mermaid` language. */
+const grammar = (): Grammar => {
+  let definition: Grammar | undefined;
+  const monacoStub = {
+    editor: { defineTheme: noop },
+    languages: {
+      register: noop,
+      registerCompletionItemProvider: noop,
+      setLanguageConfiguration: noop,
+      setMonarchTokensProvider: (_id: string, def: Grammar) => {
+        definition = def;
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+  initEditor(monacoStub);
+  if (!definition) {
+    throw new Error('initEditor did not register a tokens provider');
+  }
+  return definition;
+};
+
+/**
+ * Applies the rules of `state` to `text` the way Monarch does — first rule that matches at the
+ * start wins — and returns the matched text plus the token (or the `cases` map for keyword rules).
+ */
+const firstMatch = (state: string, text: string) => {
+  for (const [pattern, action] of grammar().tokenizer[state]) {
+    if (!(pattern instanceof RegExp)) {
+      continue;
+    }
+    const match = new RegExp(`^(?:${pattern.source})`, pattern.flags).exec(text);
+    if (match) {
+      return { action, matched: match[0] };
+    }
+  }
+  return undefined;
+};
+
+describe('mermaid Monarch grammar', () => {
+  // Monarch compiles its rules without the `u` flag, so `[A-Za-z][\w$]*` stopped at the first
+  // accented character and the rest of the identifier fell through to a later rule, picking up a
+  // different colour (#1657).
+  it.each([
+    ['flowchart', 'kávéház9ök'],
+    ['flowchart', 'ergeűáúassdf9ök'],
+    ['stateDiagram', 'Prüfung'],
+    ['classDiagram', 'Größe'],
+    ['sequenceDiagram', 'Παράδειγμα'],
+    ['journey', 'Ünnep'],
+    ['c4Diagram', 'Système'],
+    ['requirementDiagram', 'Anforderung_1']
+  ])('%s: consumes the whole accented identifier %s', (state, identifier) => {
+    expect(firstMatch(state, identifier)?.matched).toBe(identifier);
+  });
+
+  it('consumes an accented identifier up to, but not past, a separator', () => {
+    expect(firstMatch('flowchart', 'kávéház --> B')?.matched).toBe('kávéház');
+  });
+
+  it('keeps classifying ASCII keywords through the same rule', () => {
+    const match = firstMatch('flowchart', 'subgraph');
+
+    expect(match?.matched).toBe('subgraph');
+    expect((match?.action as MonarchRule).cases).toHaveProperty('@flowchartBlockKeywords');
+  });
+
+  it.each([
+    ['flowchart', 'nodeId1'],
+    ['erDiagram', 'CUSTOMER'],
+    ['sankey', 'Electricity']
+  ])('%s: leaves the ASCII identifier %s tokenized as before', (state, identifier) => {
+    expect(firstMatch(state, identifier)?.matched).toBe(identifier);
+  });
+
+  it('does not let an identifier swallow a following ASCII separator', () => {
+    expect(firstMatch('flowchart', 'A[Start]')?.matched).toBe('A');
+  });
+});

--- a/src/lib/util/monacoExtra.ts
+++ b/src/lib/util/monacoExtra.ts
@@ -4,6 +4,29 @@ import type * as Monaco from 'monaco-editor';
 
 const commentRegex = /(?<!["'])%%(?![^"']*["']\)).*$/;
 
+/**
+ * Non-ASCII letters accepted inside mermaid identifiers, as the XML `NameStartChar` ranges.
+ *
+ * Monarch compiles every rule without the `u` flag, so `\w` and `A-Za-z` are ASCII-only and an
+ * identifier such as `ergeűáú` matched only up to the first accented character — the remainder
+ * fell through the identifier rule and was left unstyled. Setting `unicode: true` on the language
+ * (which would allow `\p{L}`) is not an option: it makes the compiler reject other rules in this
+ * grammar as `Lone quantifier brackets`.
+ */
+const nonAsciiLetters =
+  '\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD';
+
+/** `[A-Za-z]`, plus the non-ASCII letters above. */
+const letter = `[A-Za-z${nonAsciiLetters}]`;
+/** `[\w$]`, plus the non-ASCII letters above. */
+const identifierChar = `[\\w$${nonAsciiLetters}]`;
+/** The identifier rule used by most diagrams: a letter followed by identifier characters. */
+const identifierRegex = new RegExp(`${letter}${identifierChar}*`);
+/** As {@link identifierRegex}, but also allowing a leading `_` or `-`. */
+const looseIdentifierRegex = new RegExp(`[-A-Z_a-z${nonAsciiLetters}]${identifierChar}*`);
+/** A run of letters, with no digits or separators. */
+const lettersRegex = new RegExp(`${letter}+`);
+
 export const initEditor = (monacoEditor: typeof Monaco): void => {
   monacoEditor.languages.register({ id: 'mermaid' });
   const requirementDiagrams = [
@@ -247,7 +270,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
         [/(title|accDescription)(.*$)/, ['keyword', 'string']],
         [/\(/, { next: 'c4DiagramParenthesis', token: 'delimiter.bracket' }],
         [
-          /[A-Z_a-z-][\w$]*/,
+          looseIdentifierRegex,
           {
             cases: {
               '@c4DiagramBlockKeywords': 'typeKeyword',
@@ -267,14 +290,14 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
         configDirectiveHandler,
         [/(^\s*(?:title|accDescription))(\s+.*$)/, ['keyword', 'string']],
         [
-          /(\*|<\|?|o|)(--|\.\.)(\*|\|?>|o|)([\t ]*[A-Za-z]+[\t ]*)(:)(.*?$)/,
+          new RegExp(`(\\*|<\\|?|o|)(--|\\.\\.)(\\*|\\|?>|o|)([\\t ]*${letter}+[\\t ]*)(:)(.*?$)`),
           ['transition', 'transition', 'transition', 'variable', 'delimiter.bracket', 'string']
         ],
-        [/(?!class\s)([A-Za-z]+)(\s+[A-Za-z]+)/, ['type', 'variable']],
+        [new RegExp(`(?!class\\s)(${letter}+)(\\s+${letter}+)`), ['type', 'variable']],
         [/(\*|<\|?|o)?(--|\.\.)(\*|\|?>|o)?/, 'transition'],
         [/^\s*class\s(?!.*{)/, 'keyword'],
         [
-          /[A-Za-z][\w$]*/,
+          identifierRegex,
           {
             cases: {
               '@classDiagramBlockKeywords': 'typeKeyword',
@@ -297,15 +320,15 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
         [/".*?"/, 'string'],
         [/(:)(.*?$)/, ['delimiter.bracket', 'string']],
         [/[:{}]/, 'delimiter.bracket'],
-        [/([A-Za-z]+)(\s+[A-Za-z]+)/, ['type', 'variable']],
+        [new RegExp(`(${letter}+)(\\s+${letter}+)`), ['type', 'variable']],
         [commentRegex, 'comment'],
-        [/[A-Z_a-z-][\w$]*/, 'variable']
+        [looseIdentifierRegex, 'variable']
       ],
       flowchart: [
         configDirectiveHandler,
         [/[ox]?(--+|==+)[ox]/, 'transition'],
         [
-          /[A-Za-z][\w$]*/,
+          identifierRegex,
           {
             cases: {
               '@default': 'variable',
@@ -334,7 +357,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
         [/(section)(.*)/, ['typeKeyword', 'string']],
         [/^\s*([^\n:]*?)(:)/, ['string', 'delimiter.bracket']],
         [
-          /[A-Za-z][\w$]*/,
+          identifierRegex,
           {
             cases: {
               '@ganttBlockKeywords': 'typeKeyword',
@@ -359,7 +382,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
           ['delimiter.bracket', 'keyword', 'variable']
         ],
         [
-          /[A-Za-z][\w$]*/,
+          identifierRegex,
           {
             cases: {
               '@gitGraphBlockKeywords': 'typeKeyword',
@@ -372,7 +395,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
       ],
       info: [
         [
-          /[A-Za-z][\w$]*/,
+          identifierRegex,
           {
             cases: {
               '@infoBlockKeywords': 'typeKeyword',
@@ -386,7 +409,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
         [/(title)(.*)/, ['keyword', 'string']],
         [/(section)(.*)/, ['typeKeyword', 'string']],
         [
-          /[A-Za-z][\w$]*/,
+          identifierRegex,
           {
             cases: {
               '@default': 'variable',
@@ -424,7 +447,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
         configDirectiveHandler,
         [/(title|accDescription)(.*$)/, ['keyword', 'string']],
         [
-          /[A-Za-z][\w$]*/,
+          identifierRegex,
           {
             cases: {
               '@pieBlockKeywords': 'typeKeyword',
@@ -442,7 +465,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
         [/->|<-|-/, 'transition'],
         [/(\d+\.)*\d+/, 'number'],
         [
-          /[A-Z_a-z-][\w$]*/,
+          looseIdentifierRegex,
           {
             cases: {
               '@default': 'variable',
@@ -480,7 +503,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
         [/(title)(.*)/, ['keyword', 'string']],
         [/(accTitle|accDescr)(\s*:)(\s*[^\n\r]+$)/, ['keyword', 'delimiter.bracket', 'string']],
         [/".*?"/, 'string'],
-        [/[A-Za-z]+/, 'string'],
+        [lettersRegex, 'string'],
         [/\s*\d+/, 'number'],
         [/,/, 'delimiter.bracket'],
         [commentRegex, 'comment']
@@ -508,7 +531,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
           ]
         ],
         [
-          /[A-Za-z][\w$]*/,
+          identifierRegex,
           {
             cases: {
               '@default': 'variable',
@@ -533,7 +556,7 @@ export const initEditor = (monacoEditor: typeof Monaco): void => {
         [/(<<)(fork|join|choice)(>>)/, 'annotation'],
         [/(\[\[)(fork|join|choice)(]])/, ['delimiter.bracket', 'annotation', 'delimiter.bracket']],
         [
-          /[A-Za-z][\w$]*/,
+          identifierRegex,
           {
             cases: {
               '@default': 'variable',


### PR DESCRIPTION
## Description

Fixes #1657 — accented characters (and anything that follows them) in the code editor were rendered in a different colour than the rest of the identifier.

### Root cause

Monaco's Monarch compiler builds every rule's `RegExp` **without the `u` flag** (`monarchCompile.js`: `const flags = (lexer.ignoreCase ? 'i' : '') + (lexer.unicode ? 'u' : '')`), so `\w` and `[A-Za-z]` are ASCII-only. The identifier rules in `monacoExtra.ts` — `/[A-Za-z][\w$]*/`, `/[A-Z_a-z-][\w$]*/`, `/[A-Za-z]+/` — therefore matched only up to the first accented character:

```
'ergeűáúassdf9ök'.match(/[A-Za-z][\w$]*/)  →  'erge'
```

The remaining `űáúassdf9ök` fell through to a later rule in the same state and picked up a different token (and so a different colour), which is exactly the two-tone rendering in the screenshots on the issue. The frontmatter looked fine because it is highlighted by a different state.

### Fix

Extend the identifier character classes with the non-ASCII letters, using the XML `NameStartChar` ranges:

```ts
const nonAsciiLetters =
  '\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D' +
  '\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD';

const identifierRegex = new RegExp(`${letter}${identifierChar}*`);       // was /[A-Za-z][\w$]*/
const looseIdentifierRegex = new RegExp(`[-A-Z_a-z${…}]${identifierChar}*`); // was /[A-Z_a-z-][\w$]*/
const lettersRegex = new RegExp(`${letter}+`);                           // was /[A-Za-z]+/
```

and use them across the affected states (`flowchart`, `classDiagram`, `stateDiagram`, `sequenceDiagram`, `erDiagram`, `gantt`, `gitGraph`, `journey`, `pie`, `info`, `sankey`, `c4Diagram`, `requirementDiagram`).

**Why not `unicode: true`?** That would let the rules use `\p{L}` and is the tidier fix in principle, but setting it on this grammar makes the compiler reject other existing rules:

```
Invalid regular expression: /^(?:\s*%%(?={))/u: Lone quantifier brackets
```

so it would require rewriting unrelated rules and is left out of this fix.

Keywords are unaffected: the rules keep their `cases` maps, and the keyword lists are all ASCII, so `subgraph` etc. still resolve to `@flowchartBlockKeywords`.

## Testing

Added `src/lib/util/monacoExtra.test.ts` (14 cases), which pulls the real grammar out of `initEditor` via a stub Monaco and applies each state's rules the way Monarch does (first rule that matches at the start wins). It covers accented identifiers across 8 diagram types, plus regression cases asserting ASCII identifiers, keywords, and separators (`A[Start]`, `kávéház --> B`) tokenize exactly as before.

**The tests fail on `master` and pass with the fix** — reverting only `monacoExtra.ts` gives 8 failures out of 14.

Local validation on this branch:

- `pnpm vitest run --dir src` → **83 passed** (9 files)
- `pnpm lint` → clean (prettier + eslint)
- `pnpm check` → **0 errors and 0 warnings**
- `pnpm build` → succeeds
