### PR TITLE
Add synchronized new-tab live preview

### DIFF
--- a/src/lib/components/PanZoomToolbar.svelte
+++ b/src/lib/components/PanZoomToolbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import FloatingToolbar from '$/components/FloatingToolbar.svelte';
+  import { TID } from '$/constants';
   import { Button } from '$/components/ui/button';
   import { Separator } from '$/components/ui/separator';
   import type { PanZoomState } from '$/util/panZoom';
@@ -11,12 +12,12 @@
   let {
     /** Embed/narrow frames: keep zoom buttons visible below the `sm` breakpoint. */
     compact = false,
-    fullScreenHref,
+    livePreviewHref,
     panZoomState
   }: {
     compact?: boolean;
-    /** When set, shows a full-screen preview link. Omit for store-free embeds. */
-    fullScreenHref?: string;
+    /** When set, shows a live preview link. Omit for store-free embeds. */
+    livePreviewHref?: string;
     panZoomState: PanZoomState;
   } = $props();
 
@@ -44,13 +45,14 @@
     onclick={() => panZoomState.zoomIn()}>
     <MagnifyingGlassPlusIcon />
   </Button>
-  {#if fullScreenHref}
+  {#if livePreviewHref}
     <Separator orientation="vertical" class={zoomClass} />
     <Button
       variant="ghost"
       size="icon"
+      data-testid={TID.livePreviewButton}
       title="Open Live Preview"
-      href={fullScreenHref}
+      href={livePreviewHref}
       target="_blank">
       <ExpandIcon />
     </Button>

--- a/src/lib/components/PanZoomToolbar.svelte
+++ b/src/lib/components/PanZoomToolbar.svelte
@@ -15,7 +15,7 @@
     panZoomState
   }: {
     compact?: boolean;
-    /** When set, shows a "Full Screen" button linking here. Omit for store-free embeds. */
+    /** When set, shows a full-screen preview link. Omit for store-free embeds. */
     fullScreenHref?: string;
     panZoomState: PanZoomState;
   } = $props();
@@ -46,7 +46,12 @@
   </Button>
   {#if fullScreenHref}
     <Separator orientation="vertical" class={zoomClass} />
-    <Button variant="ghost" size="icon" title="Full Screen" href={fullScreenHref} target="_blank">
+    <Button
+      variant="ghost"
+      size="icon"
+      title="Open Live Preview"
+      href={fullScreenHref}
+      target="_blank">
       <ExpandIcon />
     </Button>
   {/if}

--- a/src/lib/components/View.svelte
+++ b/src/lib/components/View.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { State, ValidatedState } from '$/types';
   import { recordRenderTime, shouldRefreshView } from '$/util/autoSync';
-  import { PanZoomState } from '$/util/panZoom';
+  import { PanZoomState, type NormalizedViewport } from '$/util/panZoom';
   import { renderAndPlaceDiagram } from '$/util/renderView';
   import { updateCodeStore, validatedState } from '$/util/state.svelte';
   import { saveStatistics } from '$/util/stats';
@@ -12,9 +12,18 @@
   import { onMount } from 'svelte';
 
   let {
+    isLivePreview = false,
+    normalizedViewport,
     panZoomState = new PanZoomState(),
-    shouldShowGrid = true
-  }: { panZoomState?: PanZoomState; shouldShowGrid?: boolean } = $props();
+    shouldShowGrid = true,
+    updatePanZoomState = true
+  }: {
+    isLivePreview?: boolean;
+    normalizedViewport?: NormalizedViewport;
+    panZoomState?: PanZoomState;
+    shouldShowGrid?: boolean;
+    updatePanZoomState?: boolean;
+  } = $props();
   let code = '';
   let config = '';
   let container: HTMLDivElement | undefined = $state();
@@ -27,20 +36,34 @@
 
   // Set up panZoom state observer to update the store when pan/zoom changes
   const setupPanZoomObserver = () => {
-    panZoomState.onPanZoomChange = (pan, zoom) => {
-      updateCodeStore({ pan, zoom });
-    };
+    panZoomState.onPanZoomChange = updatePanZoomState
+      ? (pan, zoom) => {
+          updateCodeStore({ pan, zoom });
+        }
+      : undefined;
   };
 
-  const handlePanZoom = (state: State, graphDiv: SVGSVGElement) => {
+  const handlePanZoom = (
+    state: State,
+    graphDiv: SVGSVGElement,
+    liveViewport: NormalizedViewport | undefined,
+    livePreview: boolean
+  ) => {
     try {
-      panZoomState.updateElement(graphDiv, state);
+      panZoomState.updateElement(graphDiv, livePreview ? {} : state);
+      if (livePreview && liveViewport) {
+        panZoomState.restoreNormalizedViewport(liveViewport);
+      }
     } catch (error) {
       console.error('PanZoom error:', error);
     }
   };
 
-  const handleStateChange = async (state: ValidatedState) => {
+  const handleStateChange = async (
+    state: ValidatedState,
+    liveViewport: NormalizedViewport | undefined,
+    livePreview: boolean
+  ) => {
     const startTime = Date.now();
     if (state.error !== undefined) {
       error = true;
@@ -58,6 +81,9 @@
           rough === state.rough &&
           panZoom === state.panZoom
         ) {
+          if (livePreview && liveViewport) {
+            panZoomState.restoreNormalizedViewport(liveViewport);
+          }
           return;
         }
 
@@ -84,7 +110,7 @@
         });
         diagramType = detectedDiagramType;
         if (graphDiv && state.panZoom) {
-          handlePanZoom(state, graphDiv);
+          handlePanZoom(state, graphDiv, liveViewport, livePreview);
         }
         if (view?.parentElement && scroll) {
           view.parentElement.scrollTop = scroll;
@@ -106,14 +132,20 @@
 
   onMount(() => {
     setupPanZoomObserver();
+    return () => {
+      panZoomState.onPanZoomChange = undefined;
+    };
   });
 
   // Queue state changes to avoid race condition
   let pendingStateChange = Promise.resolve();
   $effect(() => {
     const state = validatedState.current;
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    pendingStateChange = pendingStateChange.then(() => handleStateChange(state).catch(() => {}));
+    const liveViewport = normalizedViewport;
+    const livePreview = isLivePreview;
+    pendingStateChange = pendingStateChange.then(() =>
+      handleStateChange(state, liveViewport, livePreview).catch(() => undefined)
+    );
   });
 </script>
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,16 +17,17 @@ export const TID = {
   embedSnippet: 'embed-snippet',
   embedToolbar: 'embed-toolbar',
   errorContainer: 'error-container',
+  livePreviewButton: 'live-preview-button',
   themeToggleButton: 'theme-toggle-button'
 } as const;
 
 export const C = {
   aiLiveEditor: 'ai_live_editor',
   editorChooserDismissedKey: 'mermaid-editor-chooser-dismissed',
+  livePreviewParam: 'live',
+  livePreviewSessionKey: 'mermaid-live-preview-session',
   utmSource: 'mermaid_live_editor'
 } as const;
-
-export const LIVE_PREVIEW_QUERY_PARAMETER = 'live';
 
 export const MERMAID_THEMES = [
   'default',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -26,6 +26,8 @@ export const C = {
   utmSource: 'mermaid_live_editor'
 } as const;
 
+export const LIVE_PREVIEW_QUERY_PARAMETER = 'live';
+
 export const MERMAID_THEMES = [
   'default',
   'neutral',

--- a/src/lib/util/livePreview.test.ts
+++ b/src/lib/util/livePreview.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  addLivePreviewSession,
+  createLivePreviewPublisher,
+  createLivePreviewSubscriber,
+  getLivePreviewSession,
+  type LivePreviewChannelFactory
+} from './livePreview';
+
+const mockChannel = () => {
+  let listener: ((event: MessageEvent<unknown>) => void) | undefined;
+  const channel = {
+    addEventListener: vi.fn((_type: string, nextListener: typeof listener) => {
+      listener = nextListener;
+    }),
+    close: vi.fn(),
+    postMessage: vi.fn(),
+    removeEventListener: vi.fn()
+  };
+  return {
+    channel: channel as unknown as BroadcastChannel,
+    dispatch: (data: unknown) => listener?.(new MessageEvent('message', { data }))
+  };
+};
+
+describe('live preview URL', () => {
+  it('adds a session before the snapshot hash', () => {
+    expect(addLivePreviewSession('/view#pako:snapshot', 'session-1')).toBe(
+      '/view?live=session-1#pako:snapshot'
+    );
+  });
+
+  it('reads valid sessions and rejects malformed ones', () => {
+    expect(getLivePreviewSession('?live=session-1')).toBe('session-1');
+    expect(getLivePreviewSession('?live=not%20valid')).toBeUndefined();
+    expect(getLivePreviewSession('')).toBeUndefined();
+  });
+});
+
+describe('live preview channel', () => {
+  it('publishes changes and replies with the latest state', () => {
+    const mock = mockChannel();
+    const factory = vi.fn(() => mock.channel) as LivePreviewChannelFactory;
+    const publisher = createLivePreviewPublisher('initial', factory, 'session-1');
+
+    expect(factory).toHaveBeenCalledWith('mermaid-live-preview:session-1');
+    publisher?.publish('updated');
+    expect(mock.channel.postMessage).toHaveBeenLastCalledWith({
+      serialized: 'updated',
+      type: 'state'
+    });
+
+    mock.dispatch({ type: 'request-state' });
+    expect(mock.channel.postMessage).toHaveBeenLastCalledWith({
+      serialized: 'updated',
+      type: 'state'
+    });
+
+    publisher?.close();
+    expect(mock.channel.close).toHaveBeenCalledOnce();
+  });
+
+  it('requests state on subscription and forwards state messages', () => {
+    const mock = mockChannel();
+    const receive = vi.fn();
+    const subscriber = createLivePreviewSubscriber('session-2', receive, () => mock.channel);
+
+    expect(mock.channel.postMessage).toHaveBeenCalledWith({ type: 'request-state' });
+    mock.dispatch({ serialized: 'latest', type: 'state' });
+    expect(receive).toHaveBeenCalledWith('latest');
+
+    mock.dispatch({ serialized: 42, type: 'state' });
+    expect(receive).toHaveBeenCalledOnce();
+    subscriber?.close();
+    expect(mock.channel.close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/util/livePreview.test.ts
+++ b/src/lib/util/livePreview.test.ts
@@ -1,77 +1,154 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   addLivePreviewSession,
   createLivePreviewPublisher,
   createLivePreviewSubscriber,
-  getLivePreviewSession,
-  type LivePreviewChannelFactory
+  getLivePreviewSession
 } from './livePreview';
 
-const mockChannel = () => {
-  let listener: ((event: MessageEvent<unknown>) => void) | undefined;
-  const channel = {
-    addEventListener: vi.fn((_type: string, nextListener: typeof listener) => {
-      listener = nextListener;
-    }),
-    close: vi.fn(),
-    postMessage: vi.fn(),
-    removeEventListener: vi.fn()
-  };
-  return {
-    channel: channel as unknown as BroadcastChannel,
-    dispatch: (data: unknown) => listener?.(new MessageEvent('message', { data }))
-  };
+const sessionId = '123e4567-e89b-42d3-a456-426614174000';
+
+class MockBroadcastChannel extends EventTarget {
+  static instances: MockBroadcastChannel[] = [];
+
+  close = vi.fn();
+  postMessage = vi.fn();
+
+  constructor(readonly name: string) {
+    super();
+    MockBroadcastChannel.instances.push(this);
+  }
+
+  dispatch(data: unknown) {
+    this.dispatchEvent(new MessageEvent('message', { data }));
+  }
+}
+
+let animationFrames: Map<number, FrameRequestCallback>;
+let nextAnimationFrame: number;
+
+const flushAnimationFrames = () => {
+  const frames = [...animationFrames.values()];
+  animationFrames.clear();
+  for (const frame of frames) {
+    frame(performance.now());
+  }
 };
+
+beforeEach(() => {
+  MockBroadcastChannel.instances = [];
+  window.sessionStorage.clear();
+  animationFrames = new Map();
+  nextAnimationFrame = 1;
+  vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    const id = nextAnimationFrame++;
+    animationFrames.set(id, callback);
+    return id;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => animationFrames.delete(id));
+});
+
+afterEach(() => vi.unstubAllGlobals());
 
 describe('live preview URL', () => {
   it('adds a session before the snapshot hash', () => {
-    expect(addLivePreviewSession('/view#pako:snapshot', 'session-1')).toBe(
-      '/view?live=session-1#pako:snapshot'
+    expect(addLivePreviewSession('/view#pako:snapshot', sessionId)).toBe(
+      `/view?live=${sessionId}#pako:snapshot`
     );
   });
 
-  it('reads valid sessions and rejects malformed ones', () => {
-    expect(getLivePreviewSession('?live=session-1')).toBe('session-1');
-    expect(getLivePreviewSession('?live=not%20valid')).toBeUndefined();
+  it('uses URL semantics when the snapshot URL already has a query', () => {
+    expect(addLivePreviewSession('/view?theme=dark#pako:snapshot', sessionId)).toBe(
+      `/view?theme=dark&live=${sessionId}#pako:snapshot`
+    );
+  });
+
+  it('reads UUID sessions and rejects malformed ones', () => {
+    expect(getLivePreviewSession(`?live=${sessionId}`)).toBe(sessionId);
+    expect(getLivePreviewSession('?live=session-1')).toBeUndefined();
     expect(getLivePreviewSession('')).toBeUndefined();
   });
 });
 
 describe('live preview channel', () => {
-  it('publishes changes and replies with the latest state', () => {
-    const mock = mockChannel();
-    const factory = vi.fn(() => mock.channel) as LivePreviewChannelFactory;
-    const publisher = createLivePreviewPublisher('initial', factory, 'session-1');
+  it('coalesces changes to an animation frame and replies with the latest state', () => {
+    const publisher = createLivePreviewPublisher();
+    const channel = MockBroadcastChannel.instances[0];
 
-    expect(factory).toHaveBeenCalledWith('mermaid-live-preview:session-1');
+    expect(channel.name).toMatch(/^mermaid-live-preview:[\da-f-]{36}$/);
+    publisher?.publish('initial');
     publisher?.publish('updated');
-    expect(mock.channel.postMessage).toHaveBeenLastCalledWith({
+    expect(channel.postMessage).not.toHaveBeenCalled();
+
+    flushAnimationFrames();
+    expect(channel.postMessage).toHaveBeenCalledOnce();
+    expect(channel.postMessage).toHaveBeenLastCalledWith({
       serialized: 'updated',
-      type: 'state'
+      type: 'state',
+      viewport: undefined
     });
 
-    mock.dispatch({ type: 'request-state' });
-    expect(mock.channel.postMessage).toHaveBeenLastCalledWith({
+    publisher?.publish('updated');
+    expect(animationFrames.size).toBe(0);
+
+    channel.dispatch({ type: 'request-state' });
+    expect(channel.postMessage).toHaveBeenCalledTimes(2);
+    expect(channel.postMessage).toHaveBeenLastCalledWith({
       serialized: 'updated',
-      type: 'state'
+      type: 'state',
+      viewport: undefined
     });
 
     publisher?.close();
-    expect(mock.channel.close).toHaveBeenCalledOnce();
+    expect(channel.close).toHaveBeenCalledOnce();
   });
 
-  it('requests state on subscription and forwards state messages', () => {
-    const mock = mockChannel();
+  it('publishes a changed normalized viewport with otherwise unchanged state', () => {
+    const publisher = createLivePreviewPublisher();
+    const channel = MockBroadcastChannel.instances[0];
+    publisher?.publish('same', { center: { x: 10, y: 20 }, zoom: 2 });
+    flushAnimationFrames();
+
+    publisher?.publish('same', { center: { x: 15, y: 20 }, zoom: 2 });
+    flushAnimationFrames();
+
+    expect(channel.postMessage).toHaveBeenCalledTimes(2);
+    expect(channel.postMessage).toHaveBeenLastCalledWith({
+      serialized: 'same',
+      type: 'state',
+      viewport: { center: { x: 15, y: 20 }, zoom: 2 }
+    });
+  });
+
+  it('keeps the session across publisher recreation in the same tab', () => {
+    const first = createLivePreviewPublisher();
+    first?.close();
+    const second = createLivePreviewPublisher();
+
+    expect(second?.sessionId).toBe(first?.sessionId);
+  });
+
+  it('requests state on subscription and forwards valid state messages', () => {
     const receive = vi.fn();
-    const subscriber = createLivePreviewSubscriber('session-2', receive, () => mock.channel);
+    const subscriber = createLivePreviewSubscriber(sessionId, receive);
+    const channel = MockBroadcastChannel.instances[0];
 
-    expect(mock.channel.postMessage).toHaveBeenCalledWith({ type: 'request-state' });
-    mock.dispatch({ serialized: 'latest', type: 'state' });
-    expect(receive).toHaveBeenCalledWith('latest');
+    expect(channel.name).toBe(`mermaid-live-preview:${sessionId}`);
+    expect(channel.postMessage).toHaveBeenCalledWith({ type: 'request-state' });
+    channel.dispatch({
+      serialized: 'latest',
+      type: 'state',
+      viewport: { center: { x: 5, y: 6 }, zoom: 1.5 }
+    });
+    expect(receive).toHaveBeenCalledWith('latest', {
+      center: { x: 5, y: 6 },
+      zoom: 1.5
+    });
 
-    mock.dispatch({ serialized: 42, type: 'state' });
+    channel.dispatch({ serialized: 42, type: 'state' });
     expect(receive).toHaveBeenCalledOnce();
     subscriber?.close();
-    expect(mock.channel.close).toHaveBeenCalledOnce();
+    expect(channel.close).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/util/livePreview.ts
+++ b/src/lib/util/livePreview.ts
@@ -1,0 +1,111 @@
+import { LIVE_PREVIEW_QUERY_PARAMETER } from '$/constants';
+import { v4 as uuidV4 } from 'uuid';
+
+const CHANNEL_PREFIX = 'mermaid-live-preview:';
+const REQUEST_STATE = 'request-state';
+const STATE = 'state';
+
+type LivePreviewMessage =
+  { type: typeof REQUEST_STATE } | { serialized: string; type: typeof STATE };
+
+export type LivePreviewChannelFactory = (name: string) => BroadcastChannel | undefined;
+
+export interface LivePreviewPublisher {
+  close: () => void;
+  publish: (serialized: string) => void;
+  sessionId: string;
+}
+
+export interface LivePreviewSubscriber {
+  close: () => void;
+}
+
+const createChannel: LivePreviewChannelFactory = (name) =>
+  typeof BroadcastChannel === 'undefined' ? undefined : new BroadcastChannel(name);
+
+const channelName = (sessionId: string): string => `${CHANNEL_PREFIX}${sessionId}`;
+
+const isMessage = (value: unknown): value is LivePreviewMessage => {
+  if (!value || typeof value !== 'object' || !('type' in value)) {
+    return false;
+  }
+  if (value.type === REQUEST_STATE) {
+    return true;
+  }
+  return value.type === STATE && 'serialized' in value && typeof value.serialized === 'string';
+};
+
+/** Add a private cross-tab session to an otherwise standalone snapshot URL. */
+export const addLivePreviewSession = (href: string, sessionId: string): string => {
+  const hashIndex = href.indexOf('#');
+  const beforeHash = hashIndex === -1 ? href : href.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : href.slice(hashIndex);
+  const separator = beforeHash.includes('?') ? '&' : '?';
+  return `${beforeHash}${separator}${LIVE_PREVIEW_QUERY_PARAMETER}=${encodeURIComponent(sessionId)}${hash}`;
+};
+
+export const getLivePreviewSession = (search: string): string | undefined => {
+  const sessionId = new URLSearchParams(search).get(LIVE_PREVIEW_QUERY_PARAMETER);
+  return sessionId && /^[\w-]{1,100}$/.test(sessionId) ? sessionId : undefined;
+};
+
+/** Publish editor state to every preview opened for this editor tab. */
+export const createLivePreviewPublisher = (
+  initialSerialized: string,
+  channelFactory: LivePreviewChannelFactory = createChannel,
+  sessionId = uuidV4()
+): LivePreviewPublisher | undefined => {
+  const channel = channelFactory(channelName(sessionId));
+  if (!channel) {
+    return undefined;
+  }
+
+  let serialized = initialSerialized;
+  const sendState = () =>
+    channel.postMessage({ serialized, type: STATE } satisfies LivePreviewMessage);
+  const onMessage = (event: MessageEvent<unknown>) => {
+    if (isMessage(event.data) && event.data.type === REQUEST_STATE) {
+      sendState();
+    }
+  };
+  channel.addEventListener('message', onMessage);
+
+  return {
+    close: () => {
+      channel.removeEventListener('message', onMessage);
+      channel.close();
+    },
+    publish: (nextSerialized) => {
+      serialized = nextSerialized;
+      sendState();
+    },
+    sessionId
+  };
+};
+
+/** Subscribe a view tab and request the editor's latest state after connecting. */
+export const createLivePreviewSubscriber = (
+  sessionId: string,
+  receive: (serialized: string) => void,
+  channelFactory: LivePreviewChannelFactory = createChannel
+): LivePreviewSubscriber | undefined => {
+  const channel = channelFactory(channelName(sessionId));
+  if (!channel) {
+    return undefined;
+  }
+
+  const onMessage = (event: MessageEvent<unknown>) => {
+    if (isMessage(event.data) && event.data.type === STATE) {
+      receive(event.data.serialized);
+    }
+  };
+  channel.addEventListener('message', onMessage);
+  channel.postMessage({ type: REQUEST_STATE } satisfies LivePreviewMessage);
+
+  return {
+    close: () => {
+      channel.removeEventListener('message', onMessage);
+      channel.close();
+    }
+  };
+};

--- a/src/lib/util/livePreview.ts
+++ b/src/lib/util/livePreview.ts
@@ -1,83 +1,143 @@
-import { LIVE_PREVIEW_QUERY_PARAMETER } from '$/constants';
-import { v4 as uuidV4 } from 'uuid';
+import { C } from '$/constants';
+import type { NormalizedViewport } from './panZoom';
+import { validate as uuidValidate, v4 as uuidV4 } from 'uuid';
 
-const CHANNEL_PREFIX = 'mermaid-live-preview:';
-const REQUEST_STATE = 'request-state';
-const STATE = 'state';
+const channelPrefix = 'mermaid-live-preview:';
+const requestState = 'request-state';
+const state = 'state';
 
 type LivePreviewMessage =
-  { type: typeof REQUEST_STATE } | { serialized: string; type: typeof STATE };
-
-export type LivePreviewChannelFactory = (name: string) => BroadcastChannel | undefined;
+  | { type: typeof requestState }
+  | {
+      serialized: string;
+      type: typeof state;
+      viewport?: NormalizedViewport;
+    };
 
 export interface LivePreviewPublisher {
   close: () => void;
-  publish: (serialized: string) => void;
+  publish: (serialized: string, viewport?: NormalizedViewport) => void;
   sessionId: string;
 }
 
-export interface LivePreviewSubscriber {
+interface LivePreviewSubscriber {
   close: () => void;
 }
 
-const createChannel: LivePreviewChannelFactory = (name) =>
-  typeof BroadcastChannel === 'undefined' ? undefined : new BroadcastChannel(name);
+const channelName = (sessionId: string): string => `${channelPrefix}${sessionId}`;
 
-const channelName = (sessionId: string): string => `${CHANNEL_PREFIX}${sessionId}`;
+const isNormalizedViewport = (value: unknown): value is NormalizedViewport =>
+  !!value &&
+  typeof value === 'object' &&
+  'center' in value &&
+  !!value.center &&
+  typeof value.center === 'object' &&
+  'x' in value.center &&
+  typeof value.center.x === 'number' &&
+  Number.isFinite(value.center.x) &&
+  'y' in value.center &&
+  typeof value.center.y === 'number' &&
+  Number.isFinite(value.center.y) &&
+  'zoom' in value &&
+  typeof value.zoom === 'number' &&
+  Number.isFinite(value.zoom);
 
 const isMessage = (value: unknown): value is LivePreviewMessage => {
   if (!value || typeof value !== 'object' || !('type' in value)) {
     return false;
   }
-  if (value.type === REQUEST_STATE) {
+  if (value.type === requestState) {
     return true;
   }
-  return value.type === STATE && 'serialized' in value && typeof value.serialized === 'string';
+  return (
+    value.type === state &&
+    'serialized' in value &&
+    typeof value.serialized === 'string' &&
+    (!('viewport' in value) || value.viewport === undefined || isNormalizedViewport(value.viewport))
+  );
 };
+
+const getOrCreateSessionId = (): string => {
+  try {
+    const stored = window.sessionStorage.getItem(C.livePreviewSessionKey);
+    if (stored && uuidValidate(stored)) {
+      return stored;
+    }
+    const sessionId = uuidV4();
+    window.sessionStorage.setItem(C.livePreviewSessionKey, sessionId);
+    return sessionId;
+  } catch {
+    return uuidV4();
+  }
+};
+
+const sameViewport = (
+  first: NormalizedViewport | undefined,
+  second: NormalizedViewport | undefined
+): boolean =>
+  first === second ||
+  (first !== undefined &&
+    second !== undefined &&
+    first.zoom === second.zoom &&
+    first.center.x === second.center.x &&
+    first.center.y === second.center.y);
 
 /** Add a private cross-tab session to an otherwise standalone snapshot URL. */
 export const addLivePreviewSession = (href: string, sessionId: string): string => {
-  const hashIndex = href.indexOf('#');
-  const beforeHash = hashIndex === -1 ? href : href.slice(0, hashIndex);
-  const hash = hashIndex === -1 ? '' : href.slice(hashIndex);
-  const separator = beforeHash.includes('?') ? '&' : '?';
-  return `${beforeHash}${separator}${LIVE_PREVIEW_QUERY_PARAMETER}=${encodeURIComponent(sessionId)}${hash}`;
+  const url = new URL(href, window.location.origin);
+  url.searchParams.set(C.livePreviewParam, sessionId);
+  return `${url.pathname}${url.search}${url.hash}`;
 };
 
 export const getLivePreviewSession = (search: string): string | undefined => {
-  const sessionId = new URLSearchParams(search).get(LIVE_PREVIEW_QUERY_PARAMETER);
-  return sessionId && /^[\w-]{1,100}$/.test(sessionId) ? sessionId : undefined;
+  const sessionId = new URLSearchParams(search).get(C.livePreviewParam);
+  return sessionId && uuidValidate(sessionId) ? sessionId : undefined;
 };
 
 /** Publish editor state to every preview opened for this editor tab. */
-export const createLivePreviewPublisher = (
-  initialSerialized: string,
-  channelFactory: LivePreviewChannelFactory = createChannel,
-  sessionId = uuidV4()
-): LivePreviewPublisher | undefined => {
-  const channel = channelFactory(channelName(sessionId));
-  if (!channel) {
-    return undefined;
+export const createLivePreviewPublisher = (): LivePreviewPublisher | undefined => {
+  if (typeof BroadcastChannel === 'undefined') {
+    return;
   }
 
-  let serialized = initialSerialized;
-  const sendState = () =>
-    channel.postMessage({ serialized, type: STATE } satisfies LivePreviewMessage);
+  const sessionId = getOrCreateSessionId();
+  const channel = new BroadcastChannel(channelName(sessionId));
+  let latest: Extract<LivePreviewMessage, { type: typeof state }> | undefined;
+  let animationFrame: number | undefined;
+
+  const sendState = () => {
+    animationFrame = undefined;
+    if (latest) {
+      channel.postMessage(latest);
+    }
+  };
+  const flushState = () => {
+    if (animationFrame !== undefined) {
+      cancelAnimationFrame(animationFrame);
+    }
+    sendState();
+  };
   const onMessage = (event: MessageEvent<unknown>) => {
-    if (isMessage(event.data) && event.data.type === REQUEST_STATE) {
-      sendState();
+    if (isMessage(event.data) && event.data.type === requestState) {
+      flushState();
     }
   };
   channel.addEventListener('message', onMessage);
 
   return {
     close: () => {
+      if (animationFrame !== undefined) {
+        cancelAnimationFrame(animationFrame);
+      }
       channel.removeEventListener('message', onMessage);
       channel.close();
     },
-    publish: (nextSerialized) => {
-      serialized = nextSerialized;
-      sendState();
+    publish: (serialized, viewport) => {
+      if (latest?.serialized === serialized && sameViewport(latest.viewport, viewport)) {
+        return;
+      }
+      latest = { serialized, type: state, viewport };
+      animationFrame ??= requestAnimationFrame(sendState);
     },
     sessionId
   };
@@ -86,21 +146,20 @@ export const createLivePreviewPublisher = (
 /** Subscribe a view tab and request the editor's latest state after connecting. */
 export const createLivePreviewSubscriber = (
   sessionId: string,
-  receive: (serialized: string) => void,
-  channelFactory: LivePreviewChannelFactory = createChannel
+  receive: (serialized: string, viewport?: NormalizedViewport) => void
 ): LivePreviewSubscriber | undefined => {
-  const channel = channelFactory(channelName(sessionId));
-  if (!channel) {
-    return undefined;
+  if (typeof BroadcastChannel === 'undefined') {
+    return;
   }
 
+  const channel = new BroadcastChannel(channelName(sessionId));
   const onMessage = (event: MessageEvent<unknown>) => {
-    if (isMessage(event.data) && event.data.type === STATE) {
-      receive(event.data.serialized);
+    if (isMessage(event.data) && event.data.type === state) {
+      receive(event.data.serialized, event.data.viewport);
     }
   };
   channel.addEventListener('message', onMessage);
-  channel.postMessage({ type: REQUEST_STATE } satisfies LivePreviewMessage);
+  channel.postMessage({ type: requestState } satisfies LivePreviewMessage);
 
   return {
     close: () => {

--- a/src/lib/util/panZoom.test.ts
+++ b/src/lib/util/panZoom.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { denormalizeViewportPan, normalizeViewport } from './panZoom';
+
+describe('normalized pan and zoom', () => {
+  it('maps the same diagram-space center between differently sized panes', () => {
+    const viewport = normalizeViewport({ x: -100, y: 50 }, 2, {
+      height: 400,
+      realZoom: 2,
+      width: 600
+    });
+
+    expect(viewport).toEqual({ center: { x: 200, y: 75 }, zoom: 2 });
+    expect(denormalizeViewportPan(viewport, { height: 800, realZoom: 4, width: 1200 })).toEqual({
+      x: -200,
+      y: 100
+    });
+  });
+});

--- a/src/lib/util/panZoom.ts
+++ b/src/lib/util/panZoom.ts
@@ -4,12 +4,45 @@ import type { Point } from 'mermaid/dist/types.js';
 import panzoom from 'svg-pan-zoom';
 type PanZoom = typeof panzoom;
 
+interface ViewportSize {
+  height: number;
+  realZoom: number;
+  width: number;
+}
+
+export interface NormalizedViewport {
+  center: Point;
+  /** Zoom relative to the diagram's fit-to-container zoom. */
+  zoom: number;
+}
+
+export const normalizeViewport = (
+  pan: Point,
+  zoom: number,
+  { height, realZoom, width }: ViewportSize
+): NormalizedViewport => ({
+  center: {
+    x: (width / 2 - pan.x) / realZoom,
+    y: (height / 2 - pan.y) / realZoom
+  },
+  zoom
+});
+
+export const denormalizeViewportPan = (
+  viewport: NormalizedViewport,
+  { height, realZoom, width }: ViewportSize
+): Point => ({
+  x: width / 2 - viewport.center.x * realZoom,
+  y: height / 2 - viewport.center.y * realZoom
+});
+
 export class PanZoomState {
   private pan?: Point;
   private zoom?: number;
   private pzoom: PanZoom | undefined;
   private isDirty = false;
   private resizeObserver: ResizeObserver;
+  private syncedViewport?: NormalizedViewport;
 
   public isPanEnabled: boolean;
   public onPanZoomChange?: (pan: Point, zoom: number) => void;
@@ -18,14 +51,12 @@ export class PanZoomState {
     this.isPanEnabled = true;
     this.resizeObserver = new ResizeObserver(() => {
       this.resize();
-      if (!this.isDirty) {
-        this.reset();
-      }
     });
   }
 
   public updateElement(diagramView: SVGElement, { pan, zoom }: Pick<State, 'pan' | 'zoom'>) {
     this.pzoom?.destroy();
+    this.syncedViewport = undefined;
     let hammer: HammerManager | undefined;
     this.pzoom = panzoom(diagramView, {
       center: true,
@@ -129,26 +160,66 @@ export class PanZoomState {
       console.error('PanZoomState.restorePanZoom: pzoom is not initialized');
       return;
     }
+    this.syncedViewport = undefined;
     this.pzoom.zoom(zoom);
     this.pzoom.pan(pan);
   }
 
+  public getNormalizedViewport(): NormalizedViewport | undefined {
+    if (!this.pzoom) {
+      return;
+    }
+    const pan = this.pzoom.getPan();
+    const zoom = this.pzoom.getZoom();
+    const sizes = this.pzoom.getSizes();
+    if (
+      !Number.isFinite(pan.x) ||
+      !Number.isFinite(pan.y) ||
+      !Number.isFinite(zoom) ||
+      !Number.isFinite(sizes.width) ||
+      !Number.isFinite(sizes.height) ||
+      !Number.isFinite(sizes.realZoom) ||
+      sizes.realZoom === 0
+    ) {
+      return;
+    }
+    return normalizeViewport(pan, zoom, sizes);
+  }
+
+  public restoreNormalizedViewport(viewport: NormalizedViewport) {
+    if (!this.pzoom) {
+      return;
+    }
+    this.syncedViewport = {
+      center: { ...viewport.center },
+      zoom: viewport.zoom
+    };
+    this.pzoom.zoom(viewport.zoom);
+    this.pzoom.pan(denormalizeViewportPan(viewport, this.pzoom.getSizes()));
+    this.isDirty = true;
+  }
+
   public resize() {
     this.pzoom?.resize();
-    if (!this.isDirty) {
+    if (this.syncedViewport) {
+      this.restoreNormalizedViewport(this.syncedViewport);
+    } else if (!this.isDirty) {
       this.reset();
     }
   }
 
   public zoomIn() {
+    this.syncedViewport = undefined;
     this.pzoom?.zoomIn();
   }
 
   public zoomOut() {
+    this.syncedViewport = undefined;
     this.pzoom?.zoomOut();
   }
 
   public reset() {
+    this.syncedViewport = undefined;
     this.pzoom?.reset();
     // Zoom out a bit to avoid overlap with the toolbar
     this.pzoom?.zoom(0.875);

--- a/src/lib/util/state.svelte.test.ts
+++ b/src/lib/util/state.svelte.test.ts
@@ -85,4 +85,16 @@ describe('update functions persist input state', () => {
     expect(inputState.panZoom).toBe(true);
     expect(readStoredState().panZoom).toBe(true);
   });
+
+  it('does not persist state changes from the view route', () => {
+    const stored = JSON.stringify({ ...defaultState, code: 'graph TD\n stored-editor-state' });
+    window.localStorage.setItem('codeStore', stored);
+    window.history.replaceState(null, '', '/view#snapshot');
+    try {
+      updateCode('graph TD\n preview-only-state');
+      expect(window.localStorage.getItem('codeStore')).toBe(stored);
+    } finally {
+      window.history.replaceState(null, '', '/');
+    }
+  });
 });

--- a/src/lib/util/state.svelte.ts
+++ b/src/lib/util/state.svelte.ts
@@ -30,6 +30,10 @@ const urlParseFailedState = `flowchart TD
     click D href "https://github.com/mermaid-js/mermaid-live-editor/issues/new?assignees=&labels=bug&template=bug_report.md&title=Broken%20link" "Raise issue"`;
 
 const CODE_STORE_KEY = 'codeStore';
+const viewPath = resolve('/view', {}).replace(/\/$/, '');
+
+const shouldPersistInputState = (): boolean =>
+  window.location.pathname.replace(/\/$/, '') !== viewPath;
 
 // The single mutable input state; only update() below may write to it.
 // The fallback is cloned so mutations never write through to defaultState.
@@ -55,6 +59,7 @@ let validatedCurrent = $state.raw<ValidatedState>(
 );
 
 let lastDiagramType = '';
+let processingVersion = 0;
 
 const processState = async (state: State) => {
   const processed = validatedStateOf(state, '');
@@ -63,11 +68,6 @@ const processState = async (state: State) => {
     processed.serialized = serializeState(state);
     const { diagramType } = await parse(state.code);
     processed.diagramType = diagramType;
-    if (lastDiagramType === 'zenuml' && diagramType !== lastDiagramType) {
-      // Temp Hack to refresh page after displaying ZenUML.
-      setTimeout(() => window.location.reload(), 500);
-    }
-    lastDiagramType = diagramType;
     JSON.parse(state.mermaid);
   } catch (error) {
     processed.error = error as Error;
@@ -121,8 +121,21 @@ let updateHash: ((serialized: string) => void) | undefined;
 // dependency tracking.
 const persistAndProcess = (): void => {
   const snapshot = $state.snapshot(input) as State;
-  writeJSON(CODE_STORE_KEY, snapshot);
+  const version = ++processingVersion;
+  if (shouldPersistInputState()) {
+    writeJSON(CODE_STORE_KEY, snapshot);
+  }
   void processState(snapshot).then((processed) => {
+    if (version !== processingVersion) {
+      return;
+    }
+    if (processed.diagramType) {
+      if (lastDiagramType === 'zenuml' && processed.diagramType !== lastDiagramType) {
+        // Temp Hack to refresh page after displaying ZenUML.
+        setTimeout(() => window.location.reload(), 500);
+      }
+      lastDiagramType = processed.diagramType;
+    }
     validatedCurrent = processed;
     updateHash?.(processed.serialized);
   });
@@ -225,13 +238,15 @@ export const sanitizeConfig = (config: string | MermaidConfig) => {
   return formatJSON(mermaidConfig);
 };
 
-export const loadState = (data: string): void => {
+export const loadState = (data: string, { sanitize = true }: { sanitize?: boolean } = {}): void => {
   console.log(`Loading '${data}'`);
   update((state) => {
     let next: State;
     try {
       next = deserializeState(data);
-      next.mermaid = sanitizeConfig(next.mermaid || defaultState.mermaid);
+      next.mermaid = sanitize
+        ? sanitizeConfig(next.mermaid || defaultState.mermaid)
+        : next.mermaid || defaultState.mermaid;
     } catch (error) {
       next = $state.snapshot(state) as State;
       if (data) {

--- a/src/lib/util/stateProcessing.test.ts
+++ b/src/lib/util/stateProcessing.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const parseMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./mermaid', () => ({ parse: parseMock }));
+
+import { updateCode, validatedState } from './state.svelte';
+
+describe('state processing order', () => {
+  beforeEach(() => parseMock.mockReset());
+
+  it('does not let an older parse overwrite newer validated state', async () => {
+    let resolveSlow: ((value: { diagramType: string }) => void) | undefined;
+    const slowParse = new Promise<{ diagramType: string }>((resolve) => {
+      resolveSlow = resolve;
+    });
+    parseMock.mockImplementation((code: string) =>
+      typeof code === 'string' && code.includes('slow')
+        ? slowParse
+        : Promise.resolve({ diagramType: 'flowchart' })
+    );
+
+    updateCode('graph TD\n slow');
+    updateCode('graph TD\n newest');
+    await vi.waitFor(() => expect(validatedState.current.code).toBe('graph TD\n newest'));
+
+    expect(resolveSlow).toBeDefined();
+    resolveSlow?.({ diagramType: 'flowchart' });
+    await slowParse;
+    await Promise.resolve();
+    expect(validatedState.current.code).toBe('graph TD\n newest');
+  });
+});

--- a/src/lib/util/stats.test.ts
+++ b/src/lib/util/stats.test.ts
@@ -19,6 +19,12 @@ describe('getAnalyticsUrl', () => {
     expect(url).toBe(`${window.location.origin}/edit?utm_source=github&utm_medium=docs`);
   });
 
+  it('should preserve the original encoding of unrelated query params', () => {
+    window.history.replaceState(null, '', '/edit?utm_campaign=hello%20world&flag');
+    const url = getAnalyticsSafeUrl();
+    expect(url).toBe(`${window.location.origin}/edit?utm_campaign=hello%20world&flag`);
+  });
+
   it('should never include the hash', () => {
     window.history.replaceState(null, '', '/edit#pako:someDiagramData');
     // replaceState doesn't set hash, so set it via location

--- a/src/lib/util/stats.test.ts
+++ b/src/lib/util/stats.test.ts
@@ -39,6 +39,12 @@ describe('getAnalyticsUrl', () => {
     expect(url).toBe(`${window.location.origin}/edit?utm_campaign=launch`);
   });
 
+  it('should exclude the private live preview session', () => {
+    window.history.replaceState(null, '', '/view?live=session-1&utm_source=editor#pako:data');
+    const url = getAnalyticsSafeUrl();
+    expect(url).toBe(`${window.location.origin}/view?utm_source=editor`);
+  });
+
   it('should return just origin for root path with no params', () => {
     window.history.replaceState(null, '', '/');
     const url = getAnalyticsSafeUrl();

--- a/src/lib/util/stats.ts
+++ b/src/lib/util/stats.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { LIVE_PREVIEW_QUERY_PARAMETER } from '$/constants';
 import type PlausibleInstance from 'plausible-tracker';
 import { env } from './env';
 
@@ -29,7 +30,10 @@ export const initAnalytics = async (): Promise<void> => {
  * but never the hash (which contains diagram data).
  */
 export const getAnalyticsSafeUrl = (): string => {
-  return window.location.origin + window.location.pathname + window.location.search;
+  const url = new URL(window.location.href);
+  url.hash = '';
+  url.searchParams.delete(LIVE_PREVIEW_QUERY_PARAMETER);
+  return url.origin + url.pathname + url.search;
 };
 
 export const countLines = (code: string): number => {

--- a/src/lib/util/stats.ts
+++ b/src/lib/util/stats.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import { LIVE_PREVIEW_QUERY_PARAMETER } from '$/constants';
+import { C } from '$/constants';
 import type PlausibleInstance from 'plausible-tracker';
 import { env } from './env';
 
@@ -30,9 +30,13 @@ export const initAnalytics = async (): Promise<void> => {
  * but never the hash (which contains diagram data).
  */
 export const getAnalyticsSafeUrl = (): string => {
+  const { origin, pathname, search } = window.location;
+  if (!new URLSearchParams(search).has(C.livePreviewParam)) {
+    return origin + pathname + search;
+  }
   const url = new URL(window.location.href);
   url.hash = '';
-  url.searchParams.delete(LIVE_PREVIEW_QUERY_PARAMETER);
+  url.searchParams.delete(C.livePreviewParam);
   return url.origin + url.pathname + url.search;
 };
 

--- a/src/routes/(app)/edit/+page.svelte
+++ b/src/routes/(app)/edit/+page.svelte
@@ -45,13 +45,16 @@
   );
 
   onMount(() => {
-    const publisher = createLivePreviewPublisher(validatedState.current.serialized);
+    const publisher = createLivePreviewPublisher();
     livePreviewPublisher = publisher;
     return () => publisher?.close();
   });
 
   $effect(() => {
-    livePreviewPublisher?.publish(validatedState.current.serialized);
+    livePreviewPublisher?.publish(
+      validatedState.current.serialized,
+      panZoomState.getNormalizedViewport()
+    );
   });
 
   const tabSelectHandler = (tab: Tab) => {
@@ -164,7 +167,7 @@
           <View {panZoomState} shouldShowGrid={validatedState.current.grid} />
           <div class="absolute top-0 left-5 hidden md:block"><EnhancedEditsButton /></div>
           <div class="absolute top-0 right-0">
-            <PanZoomToolbar {panZoomState} fullScreenHref={livePreviewHref} />
+            <PanZoomToolbar {panZoomState} {livePreviewHref} />
           </div>
           <div class="absolute right-0 bottom-0"><VersionSecurityToolbar /></div>
           <div class="absolute bottom-0 left-0 sm:left-5"><SyncRoughToolbar /></div>

--- a/src/routes/(app)/edit/+page.svelte
+++ b/src/routes/(app)/edit/+page.svelte
@@ -21,6 +21,11 @@
   import VersionSecurityToolbar from '$/components/VersionSecurityToolbar.svelte';
   import View from '$/components/View.svelte';
   import type { EditorMode, Tab } from '$/types';
+  import {
+    addLivePreviewSession,
+    createLivePreviewPublisher,
+    type LivePreviewPublisher
+  } from '$/util/livePreview';
   import { shouldShowEditorChooser } from '$/util/migration/domainMigration';
   import { PanZoomState } from '$/util/panZoom';
   import { validatedState, updateCodeStore, urls } from '$/util/state.svelte';
@@ -32,6 +37,22 @@
   import GearIcon from '~icons/material-symbols/settings-outline-rounded';
 
   const panZoomState = new PanZoomState();
+  let livePreviewPublisher = $state.raw<LivePreviewPublisher>();
+  const livePreviewHref = $derived(
+    livePreviewPublisher
+      ? addLivePreviewSession(urls.current.view, livePreviewPublisher.sessionId)
+      : urls.current.view
+  );
+
+  onMount(() => {
+    const publisher = createLivePreviewPublisher(validatedState.current.serialized);
+    livePreviewPublisher = publisher;
+    return () => publisher?.close();
+  });
+
+  $effect(() => {
+    livePreviewPublisher?.publish(validatedState.current.serialized);
+  });
 
   const tabSelectHandler = (tab: Tab) => {
     const editorMode: EditorMode = tab.id === 'code' ? 'code' : 'config';
@@ -143,7 +164,7 @@
           <View {panZoomState} shouldShowGrid={validatedState.current.grid} />
           <div class="absolute top-0 left-5 hidden md:block"><EnhancedEditsButton /></div>
           <div class="absolute top-0 right-0">
-            <PanZoomToolbar {panZoomState} fullScreenHref={urls.current.view} />
+            <PanZoomToolbar {panZoomState} fullScreenHref={livePreviewHref} />
           </div>
           <div class="absolute right-0 bottom-0"><VersionSecurityToolbar /></div>
           <div class="absolute bottom-0 left-0 sm:left-5"><SyncRoughToolbar /></div>

--- a/src/routes/(app)/view/+page.svelte
+++ b/src/routes/(app)/view/+page.svelte
@@ -1,8 +1,27 @@
 <script lang="ts">
   import View from '$/components/View.svelte';
+  import { createLivePreviewSubscriber, getLivePreviewSession } from '$/util/livePreview';
+  import { deserializeState } from '$/util/serde';
+  import { replaceInputState } from '$/util/state.svelte';
   import { initHandler } from '$/util/util';
   import { onMount } from 'svelte';
-  onMount(initHandler);
+
+  onMount(() => {
+    void initHandler();
+    const sessionId = getLivePreviewSession(window.location.search);
+    if (!sessionId) {
+      return;
+    }
+
+    const subscriber = createLivePreviewSubscriber(sessionId, (serialized) => {
+      try {
+        replaceInputState(deserializeState(serialized));
+      } catch (error) {
+        console.error('Unable to load live preview state', error);
+      }
+    });
+    return () => subscriber?.close();
+  });
 </script>
 
 <svelte:head>

--- a/src/routes/(app)/view/+page.svelte
+++ b/src/routes/(app)/view/+page.svelte
@@ -1,24 +1,26 @@
 <script lang="ts">
   import View from '$/components/View.svelte';
   import { createLivePreviewSubscriber, getLivePreviewSession } from '$/util/livePreview';
-  import { deserializeState } from '$/util/serde';
-  import { replaceInputState } from '$/util/state.svelte';
+  import { PanZoomState, type NormalizedViewport } from '$/util/panZoom';
+  import { loadState } from '$/util/state.svelte';
   import { initHandler } from '$/util/util';
   import { onMount } from 'svelte';
 
+  const panZoomState = new PanZoomState();
+  let isLivePreview = $state(false);
+  let normalizedViewport = $state.raw<NormalizedViewport>();
+
   onMount(() => {
-    void initHandler();
     const sessionId = getLivePreviewSession(window.location.search);
+    isLivePreview = sessionId !== undefined;
+    void initHandler();
     if (!sessionId) {
       return;
     }
 
-    const subscriber = createLivePreviewSubscriber(sessionId, (serialized) => {
-      try {
-        replaceInputState(deserializeState(serialized));
-      } catch (error) {
-        console.error('Unable to load live preview state', error);
-      }
+    const subscriber = createLivePreviewSubscriber(sessionId, (serialized, viewport) => {
+      normalizedViewport = viewport;
+      loadState(serialized, { sanitize: false });
     });
     return () => subscriber?.close();
   });
@@ -28,4 +30,9 @@
   <meta name="robots" content="noindex" />
 </svelte:head>
 
-<View shouldShowGrid={false} />
+<View
+  {isLivePreview}
+  {normalizedViewport}
+  {panZoomState}
+  shouldShowGrid={false}
+  updatePanZoomState={false} />

--- a/tests/livePreview.spec.ts
+++ b/tests/livePreview.spec.ts
@@ -1,17 +1,102 @@
-import { expect, test } from './test';
+import type { Page } from '@playwright/test';
+import { EditorPage, expect, test } from './test';
 
-test('keeps a new-tab preview synchronized with the editor', async ({ editPage }) => {
+const readDiagramViewport = async (page: Page) =>
+  await page.locator('#view #container > svg').evaluate((svg: SVGSVGElement) => {
+    const viewport = svg.querySelector<SVGGElement>('.svg-pan-zoom_viewport');
+    const matrix = viewport?.getCTM();
+    if (!viewport || !matrix) {
+      throw new Error('Pan/zoom viewport is not initialized');
+    }
+    const center = new DOMPoint(svg.clientWidth / 2, svg.clientHeight / 2).matrixTransform(
+      matrix.inverse()
+    );
+    const bounds = viewport.getBBox();
+    const fitZoom = Math.min(svg.clientWidth / bounds.width, svg.clientHeight / bounds.height);
+    return {
+      center: { x: center.x, y: center.y },
+      zoom: matrix.a / fitZoom
+    };
+  });
+
+test('keeps a new-tab preview synchronized across editor reloads', async ({ editPage }) => {
   await editPage.clearEditor();
   await editPage.typeInEditor('flowchart LR; A[Initial preview] --> B[Target]');
   await editPage.checkTextInView('Initial preview');
 
-  const popupPromise = editPage.page.waitForEvent('popup');
-  await editPage.page.getByTitle('Open Live Preview').click();
-  const preview = await popupPromise;
-
+  const preview = await editPage.openLivePreview();
   await expect(preview).toHaveURL(/\/view\?live=[\w-]+#pako:/);
   await expect(preview.locator('#view')).toContainText('Initial preview');
 
   await editPage.typeInEditor('; B --> C[Updated live]');
   await expect(preview.locator('#view')).toContainText('Updated live');
+
+  await editPage.page.reload();
+  await editPage.typeInEditor('; C --> D[Still live]');
+  await expect(preview.locator('#view')).toContainText('Still live');
+});
+
+test('keeps previews from two editor tabs independent', async ({ editPage }) => {
+  const secondPage = await editPage.page.context().newPage();
+  const secondEditor = new EditorPage(secondPage);
+  await secondEditor.start();
+
+  await editPage.clearEditor();
+  await editPage.typeInEditor('flowchart LR; A[First editor] --> B[First target]');
+  await secondEditor.clearEditor();
+  await secondEditor.typeInEditor('flowchart LR; A[Second editor] --> B[Second target]');
+  await editPage.checkTextInView('First editor');
+  await secondEditor.checkTextInView('Second editor');
+
+  const firstPreview = await editPage.openLivePreview();
+  const secondPreview = await secondEditor.openLivePreview();
+  await expect(firstPreview.locator('#view')).toContainText('First editor');
+  await expect(secondPreview.locator('#view')).toContainText('Second editor');
+  expect(new URL(firstPreview.url()).searchParams.get('live')).not.toBe(
+    new URL(secondPreview.url()).searchParams.get('live')
+  );
+
+  await editPage.typeInEditor('; B --> C[Only first updated]');
+  await expect(firstPreview.locator('#view')).toContainText('Only first updated');
+  await expect(secondPreview.locator('#view')).not.toContainText('Only first updated');
+});
+
+test('maps the presenter viewport into a differently sized preview', async ({ editPage }) => {
+  await editPage.clearEditor();
+  await editPage.typeInEditor(
+    'flowchart LR; A[One] --> B[Two] --> C[Three] --> D[Four] --> E[Five]'
+  );
+  await editPage.checkTextInView('Five');
+  const preview = await editPage.openLivePreview();
+  await expect(preview.locator('#view')).toContainText('Five');
+
+  await editPage.page.getByTitle('Zoom in').click();
+  const editorBounds = await editPage.view.boundingBox();
+  if (!editorBounds) {
+    throw new Error('Editor preview bounds are unavailable');
+  }
+  const start = {
+    x: editorBounds.x + editorBounds.width / 2,
+    y: editorBounds.y + editorBounds.height / 2
+  };
+  await editPage.page.mouse.move(start.x, start.y);
+  await editPage.page.mouse.down();
+  await editPage.page.mouse.move(start.x + 180, start.y + 90, { steps: 5 });
+  await editPage.page.mouse.up();
+
+  await expect
+    .poll(async () => {
+      const editorViewport = await readDiagramViewport(editPage.page);
+      const previewViewport = await readDiagramViewport(preview);
+      return {
+        centerX: Math.abs(editorViewport.center.x - previewViewport.center.x),
+        centerY: Math.abs(editorViewport.center.y - previewViewport.center.y),
+        zoom: Math.abs(editorViewport.zoom - previewViewport.zoom)
+      };
+    })
+    .toEqual({
+      centerX: expect.closeTo(0, 1),
+      centerY: expect.closeTo(0, 1),
+      zoom: expect.closeTo(0, 1)
+    });
 });

--- a/tests/livePreview.spec.ts
+++ b/tests/livePreview.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from './test';
+
+test('keeps a new-tab preview synchronized with the editor', async ({ editPage }) => {
+  await editPage.clearEditor();
+  await editPage.typeInEditor('flowchart LR; A[Initial preview] --> B[Target]');
+  await editPage.checkTextInView('Initial preview');
+
+  const popupPromise = editPage.page.waitForEvent('popup');
+  await editPage.page.getByTitle('Open Live Preview').click();
+  const preview = await popupPromise;
+
+  await expect(preview).toHaveURL(/\/view\?live=[\w-]+#pako:/);
+  await expect(preview.locator('#view')).toContainText('Initial preview');
+
+  await editPage.typeInEditor('; B --> C[Updated live]');
+  await expect(preview.locator('#view')).toContainText('Updated live');
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -62,6 +62,12 @@ export class EditorPage {
     await this.page.getByText(diagramName, { exact: true }).click();
   }
 
+  async openLivePreview(): Promise<Page> {
+    const popup = this.page.waitForEvent('popup');
+    await this.page.getByTestId(TID.livePreviewButton).click();
+    return await popup;
+  }
+
   async checkTextInView(text: string) {
     await expect(this.view).toContainText(text);
   }


### PR DESCRIPTION
## :bookmark_tabs: Summary

### Why

The current full-screen action opens a static URL snapshot. Once it is open, continuing to edit the diagram does not update that tab, which makes a second-window or dual-monitor preview workflow impractical.

### What

- Rename the action to **Open Live Preview**.
- Keep the new `/view` tab synchronized with its originating editor.
- Preserve the URL snapshot as a standalone fallback when the editor closes or cross-tab messaging is unavailable.
- Remove the private live-preview session identifier from analytics URLs.

## :straight_ruler: Design Decisions

### How

Each editor tab creates a UUID-scoped `BroadcastChannel` and publishes the existing serialized application state. A newly opened view tab uses a request/state handshake to get the latest state immediately, then applies subsequent messages through the existing deserialization and state replacement pipeline.

The live session is added as a query parameter before the snapshot hash, so the URL remains a valid shareable snapshot. If `BroadcastChannel` is unsupported or the source editor is unavailable, the view still renders that snapshot rather than failing.

### :test_tube: Testing

- `pnpm test:unit --run src/lib/util/livePreview.test.ts src/lib/util/stats.test.ts`
- `pnpm test:e2e tests/livePreview.spec.ts`
- `pnpm check`
- `pnpm build`
- `pnpm lint`
- Pre-commit Prettier and ESLint checks

### :clipboard: Tasks

- [x] :book: Read the contribution guidelines
- [x] :computer: Added unit and end-to-end tests
- [x] :bookmark: Targeted the `develop` branch