### PR TITLE
feat: A/B test visual-editor banner against JS26 discount

### DIFF
--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -12,6 +12,7 @@
   import MainMenu from '$/components/MainMenu.svelte';
   import { Button } from '$/components/ui/button';
   import { Separator } from '$/components/ui/separator';
+  import { TID } from '$/constants';
   import { dismissPromotion, getActivePromotion } from '$lib/util/promos/promo.svelte';
   import { untrack, type ComponentProps, type Snippet } from 'svelte';
   import MermaidIcon from '~icons/custom/mermaid';
@@ -48,14 +49,15 @@
       return;
     }
     logEvent('bannerClick', {
-      promotion: activePromotion.id
+      promotion: activePromotion.id,
+      ...(activePromotion.variant ? { variant: activePromotion.variant } : {})
     });
     logMermaidChartClick('banner');
   };
 </script>
 
 {#if activePromotion}
-  <div class="top-bar z-10 flex h-fit w-full bg-primary">
+  <div class="top-bar z-10 flex h-fit w-full bg-primary" data-testid={TID.promoBanner}>
     <div
       class="flex grow"
       role="button"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,6 +17,7 @@ export const TID = {
   embedSnippet: 'embed-snippet',
   embedToolbar: 'embed-toolbar',
   errorContainer: 'error-container',
+  promoBanner: 'promo-banner',
   themeToggleButton: 'theme-toggle-button'
 } as const;
 

--- a/src/lib/util/promos/VisualTestB.svelte
+++ b/src/lib/util/promos/VisualTestB.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { Button } from '$/components/ui/button';
+  import { getSignupUrl } from '$/util/util';
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    closeBanner: Snippet;
+  }
+
+  let { closeBanner }: Props = $props();
+
+  const url = getSignupUrl({ utmCampaign: 'visual_testB', utmMedium: 'banner_ad' });
+</script>
+
+<div class="flex w-full items-center bg-[#E0095F] p-1.5" role="banner">
+  <div class="grid grow">
+    <a
+      href={url}
+      target="_blank"
+      class="col-start-1 row-start-1 flex items-center justify-center gap-4 no-underline">
+      <span class="text-base tracking-wider text-white">
+        Use the Visual Editor in Mermaid to edit diagrams with your mouse
+      </span>
+      <Button
+        class="shrink-0 rounded-md bg-[#1E1A2E] px-3 py-1.5 text-base font-semibold tracking-wide text-white hover:bg-[#261A56]">
+        Try it now
+      </Button>
+    </a>
+  </div>
+  {@render closeBanner()}
+</div>

--- a/src/lib/util/promos/bannerAb.test.ts
+++ b/src/lib/util/promos/bannerAb.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { C } from '$/constants';
+import { MCBaseURL } from '$/util/env';
+import { getSignupUrl } from '$/util/util';
+import { assignBannerVariant, BANNER_AB_KEY, getBannerVariant } from './bannerAb';
+
+describe('assignBannerVariant', () => {
+  it('returns the stored variant without re-rolling', () => {
+    expect(assignBannerVariant('control', () => 0.9)).toBe('control');
+    expect(assignBannerVariant('testB', () => 0.1)).toBe('testB');
+  });
+
+  it('assigns control when the random draw is below 0.5', () => {
+    expect(assignBannerVariant(undefined, () => 0.49)).toBe('control');
+  });
+
+  it('assigns testB when the random draw is 0.5 or above', () => {
+    expect(assignBannerVariant(undefined, () => 0.5)).toBe('testB');
+  });
+
+  it('re-assigns when stored value is invalid', () => {
+    expect(assignBannerVariant('promo-js-2026', () => 0.1)).toBe('control');
+    expect(assignBannerVariant('', () => 0.8)).toBe('testB');
+  });
+});
+
+describe('getBannerVariant', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('persists a new assignment so later visits stay sticky', () => {
+    expect(getBannerVariant(() => 0.8)).toBe('testB');
+    expect(window.localStorage.getItem(BANNER_AB_KEY)).toBe('"testB"');
+    expect(getBannerVariant(() => 0.1)).toBe('testB');
+  });
+});
+
+describe('getSignupUrl', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/edit');
+  });
+
+  it('points at the Mermaid Chart sign-up page with banner UTMs', () => {
+    const url = new URL(getSignupUrl({ utmCampaign: 'visual_testB', utmMedium: 'banner_ad' }));
+
+    expect(url.origin + url.pathname).toBe(`${MCBaseURL}/app/sign-up`);
+    expect(url.searchParams.get('utm_source')).toBe(C.utmSource);
+    expect(url.searchParams.get('utm_medium')).toBe('banner_ad');
+    expect(url.searchParams.get('utm_campaign')).toBe('visual_testB');
+  });
+});

--- a/src/lib/util/promos/bannerAb.ts
+++ b/src/lib/util/promos/bannerAb.ts
@@ -1,0 +1,25 @@
+import { readJSON, writeJSON } from '../persist.svelte';
+
+export const BANNER_AB_KEY = 'bannerAbVariant';
+export const BANNER_AB_VARIANTS = ['control', 'testB'] as const;
+
+export type BannerAbVariant = (typeof BANNER_AB_VARIANTS)[number];
+
+export const isBannerAbVariant = (value: unknown): value is BannerAbVariant =>
+  value === 'control' || value === 'testB';
+
+export const assignBannerVariant = (
+  stored: unknown,
+  random: () => number = Math.random
+): BannerAbVariant => {
+  if (isBannerAbVariant(stored)) {
+    return stored;
+  }
+  return random() < 0.5 ? 'control' : 'testB';
+};
+
+export const getBannerVariant = (random: () => number = Math.random): BannerAbVariant => {
+  const assigned = assignBannerVariant(readJSON<unknown>(BANNER_AB_KEY, undefined), random);
+  writeJSON(BANNER_AB_KEY, assigned);
+  return assigned;
+};

--- a/src/lib/util/promos/promo.svelte.test.ts
+++ b/src/lib/util/promos/promo.svelte.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { writeJSON } from '../persist.svelte';
+import { BANNER_AB_KEY } from './bannerAb';
+import JS2026 from './JS2026.svelte';
+import { getActivePromotion } from './promo.svelte';
+import VisualTestB from './VisualTestB.svelte';
+
+describe('getActivePromotion A/B', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('keeps the discount banner for the control bucket', () => {
+    writeJSON(BANNER_AB_KEY, 'control');
+    const promo = getActivePromotion();
+    expect(promo?.id).toBe('promo-js-2026');
+    expect(promo?.variant).toBe('control');
+    expect(promo?.component).toBe(JS2026);
+  });
+
+  it('swaps in the visual-editor banner for the testB bucket', () => {
+    writeJSON(BANNER_AB_KEY, 'testB');
+    const promo = getActivePromotion();
+    expect(promo?.id).toBe('promo-js-2026');
+    expect(promo?.variant).toBe('testB');
+    expect(promo?.component).toBe(VisualTestB);
+  });
+});

--- a/src/lib/util/promos/promo.svelte.ts
+++ b/src/lib/util/promos/promo.svelte.ts
@@ -4,7 +4,9 @@ import duration from 'dayjs/plugin/duration';
 import type { Component, Snippet } from 'svelte';
 import { persisted } from '../persist.svelte';
 import April2025 from './April2025.svelte';
+import { getBannerVariant, type BannerAbVariant } from './bannerAb';
 import JS2026 from './JS2026.svelte';
+import VisualTestB from './VisualTestB.svelte';
 
 dayjs.extend(duration);
 
@@ -14,6 +16,8 @@ interface Promotion {
   component: Component<{ closeBanner: Snippet }>;
   hideDurationMs: number;
 }
+
+export type ActivePromotion = Promotion & { id: string; variant?: BannerAbVariant };
 
 const promotions: Record<string, Promotion> = {
   'promo-js-2026': {
@@ -42,7 +46,7 @@ export const dismissPromotion = (id?: string): void => {
 
 const hiddenPromotions = persisted<Record<string, number>>('hiddenPromotions', {});
 
-export const getActivePromotion = (): (Promotion & { id: string }) | undefined => {
+export const getActivePromotion = (): ActivePromotion | undefined => {
   if (!env.isEnabledMermaidChartLinks) {
     return;
   }
@@ -64,5 +68,15 @@ export const getActivePromotion = (): (Promotion & { id: string }) | undefined =
   }
 
   const [id, promotion] = promotionWithID;
-  return { ...promotion, id };
+  if (id !== 'promo-js-2026') {
+    return { ...promotion, id };
+  }
+
+  const variant = getBannerVariant();
+  return {
+    ...promotion,
+    component: variant === 'testB' ? VisualTestB : promotion.component,
+    id,
+    variant
+  };
 };

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -60,6 +60,10 @@ export const getCheckoutUrl = (utm: { utmCampaign: string; utmMedium: string }):
   return `${MCBaseURL}/app/user/billing/checkout?${params.toString()}`;
 };
 
+export const getSignupUrl = (utm: { utmCampaign: string; utmMedium: string }): string => {
+  return `${MCBaseURL}/app/sign-up?${buildUtmParams(utm).toString()}`;
+};
+
 export const getMermaidAiLiveUrl = (utm: { utmCampaign: string; utmMedium: string }): string => {
   return `${MCBaseURL}/live?${buildUtmParams(utm).toString()}`;
 };

--- a/tests/bannerAb.spec.ts
+++ b/tests/bannerAb.spec.ts
@@ -1,0 +1,43 @@
+import { C, TID } from '$/constants';
+import { BANNER_AB_KEY } from '$/util/promos/bannerAb';
+import type { Page } from '@playwright/test';
+import { expect, test } from './test';
+
+const seedBanner = async (page: Page, variant: 'control' | 'testB') => {
+  await page.addInitScript(
+    ({ dismissedKey, variantKey, variant }) => {
+      localStorage.setItem(dismissedKey, 'true');
+      localStorage.setItem(variantKey, JSON.stringify(variant));
+    },
+    {
+      dismissedKey: C.editorChooserDismissedKey,
+      variant,
+      variantKey: BANNER_AB_KEY
+    }
+  );
+  await page.goto('/edit');
+};
+
+test.describe('Banner A/B', () => {
+  test('control keeps the discount banner and checkout UTMs', async ({ page }) => {
+    await seedBanner(page, 'control');
+    const banner = page.getByTestId(TID.promoBanner);
+    await expect(banner).toContainText('OSS users get 10% off with code JS26');
+    await expect(banner.locator('a')).toHaveAttribute('href', /utm_campaign=oss_coupon/);
+    await expect(banner.locator('a')).toHaveAttribute('href', /utm_medium=banner_ad/);
+    await expect(banner.locator('a')).toHaveAttribute('href', /utm_source=mermaid_live_editor/);
+  });
+
+  test('testB shows the visual-editor CTA and sign-up UTMs', async ({ page }) => {
+    await seedBanner(page, 'testB');
+    const banner = page.getByTestId(TID.promoBanner);
+    await expect(banner).toContainText(
+      'Use the Visual Editor in Mermaid to edit diagrams with your mouse'
+    );
+    await expect(banner.getByRole('button', { name: 'Try it now' })).toBeVisible();
+    await expect(banner.locator('a')).toHaveAttribute('href', /\/app\/sign-up/);
+    await expect(banner.locator('a')).toHaveAttribute('href', /utm_campaign=visual_testB/);
+    await expect(banner.locator('a')).toHaveAttribute('href', /utm_medium=banner_ad/);
+    await expect(banner.locator('a')).toHaveAttribute('href', /utm_source=mermaid_live_editor/);
+  });
+});


### PR DESCRIPTION
## Summary
- Sticky 50/50 A/B on the current JS26 discount banner vs a visual-editor CTA (collab#5616).
- testB copy: "Use the Visual Editor in Mermaid to edit diagrams with your mouse" → `/app/sign-up` with `utm_medium=banner_ad&utm_campaign=visual_testB` and host-specific `utm_source`.
- `bannerClick` now includes `variant` so we can measure CTR alongside mermaid.ai conversion.

## Test plan
- [ ] Land on `/edit` with empty `localStorage.bannerAbVariant` — banner is either control (JS26 coupon/checkout) or testB (visual editor/signup)
- [ ] Reload — same variant sticks
- [ ] Control link: `utm_campaign=oss_coupon&utm_medium=banner_ad&utm_source=mermaid_live_editor`
- [ ] testB link: `/app/sign-up?utm_campaign=visual_testB&utm_medium=banner_ad&utm_source=mermaid_live_editor`
- [ ] Dismiss still hides the JS26 slot (April2025 fallback unchanged)
- [ ] `pnpm vitest run --dir src` and `pnpm exec playwright test tests/bannerAb.spec.ts`


Made with [Cursor](https://cursor.com)